### PR TITLE
feat(infra): implement CloudFront + S3 hosting stack

### DIFF
--- a/infra/lib/hosting-stack.ts
+++ b/infra/lib/hosting-stack.ts
@@ -1,10 +1,70 @@
 import * as cdk from 'aws-cdk-lib';
+import * as cloudfront from 'aws-cdk-lib/aws-cloudfront';
+import * as origins from 'aws-cdk-lib/aws-cloudfront-origins';
+import * as s3 from 'aws-cdk-lib/aws-s3';
 import { Construct } from 'constructs';
 
+/**
+ * HostingStack provisions the static site hosting infrastructure for ABLE Tracker:
+ * - An S3 bucket for static site assets (private, versioned)
+ * - A CloudFront distribution with OAC (Origin Access Control)
+ * - SPA routing via custom error responses (403/404 -> /index.html)
+ */
 export class HostingStack extends cdk.Stack {
+  /** The S3 bucket holding the frontend build artifacts. */
+  public readonly frontendBucket: s3.Bucket;
+
+  /** The CloudFront distribution serving the frontend. */
+  public readonly distribution: cloudfront.Distribution;
+
   constructor(scope: Construct, id: string, props?: cdk.StackProps) {
     super(scope, id, props);
 
-    // TODO: S3 bucket, CloudFront distribution
+    // --- S3 Bucket for Static Assets ---
+    this.frontendBucket = new s3.Bucket(this, 'FrontendBucket', {
+      blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
+      versioned: true,
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
+      autoDeleteObjects: true,
+    });
+
+    // --- CloudFront Distribution with OAC ---
+    this.distribution = new cloudfront.Distribution(this, 'Distribution', {
+      defaultBehavior: {
+        origin: origins.S3BucketOrigin.withOriginAccessControl(this.frontendBucket),
+        viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
+      },
+      defaultRootObject: 'index.html',
+      priceClass: cloudfront.PriceClass.PRICE_CLASS_100,
+      // SPA routing: redirect 403/404 errors to /index.html so React Router handles them
+      errorResponses: [
+        {
+          httpStatus: 403,
+          responseHttpStatus: 200,
+          responsePagePath: '/index.html',
+        },
+        {
+          httpStatus: 404,
+          responseHttpStatus: 200,
+          responsePagePath: '/index.html',
+        },
+      ],
+    });
+
+    // --- Stack Outputs ---
+    new cdk.CfnOutput(this, 'FrontendBucketName', {
+      value: this.frontendBucket.bucketName,
+      description: 'S3 bucket name for frontend static assets',
+    });
+
+    new cdk.CfnOutput(this, 'DistributionId', {
+      value: this.distribution.distributionId,
+      description: 'CloudFront distribution ID for cache invalidation',
+    });
+
+    new cdk.CfnOutput(this, 'DistributionDomainName', {
+      value: this.distribution.distributionDomainName,
+      description: 'CloudFront distribution domain name (URL for users)',
+    });
   }
 }

--- a/infra/test/hosting-stack.test.ts
+++ b/infra/test/hosting-stack.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import * as cdk from 'aws-cdk-lib';
+import { Template, Match } from 'aws-cdk-lib/assertions';
+import { HostingStack } from '../lib/hosting-stack.js';
+
+describe('HostingStack', () => {
+  let template: Template;
+  let stack: HostingStack;
+
+  beforeAll(() => {
+    const app = new cdk.App();
+    stack = new HostingStack(app, 'TestHostingStack');
+    template = Template.fromStack(stack);
+  });
+
+  describe('S3 Bucket', () => {
+    it('creates an S3 bucket with BlockPublicAccess.BLOCK_ALL', () => {
+      template.hasResourceProperties('AWS::S3::Bucket', {
+        PublicAccessBlockConfiguration: {
+          BlockPublicAcls: true,
+          BlockPublicPolicy: true,
+          IgnorePublicAcls: true,
+          RestrictPublicBuckets: true,
+        },
+      });
+    });
+
+    it('enables versioning', () => {
+      template.hasResourceProperties('AWS::S3::Bucket', {
+        VersioningConfiguration: {
+          Status: 'Enabled',
+        },
+      });
+    });
+
+    it('has DESTROY removal policy for dev convenience', () => {
+      // When removalPolicy is DESTROY, CDK sets DeletionPolicy to Delete
+      const buckets = template.findResources('AWS::S3::Bucket');
+      const bucketKeys = Object.keys(buckets);
+      expect(bucketKeys.length).toBeGreaterThanOrEqual(1);
+
+      // Find the frontend bucket (the one with versioning, not the auto-delete custom resource)
+      const frontendBucket = bucketKeys.find(
+        (key) => buckets[key].Properties?.VersioningConfiguration?.Status === 'Enabled',
+      );
+      expect(frontendBucket).toBeDefined();
+      expect(buckets[frontendBucket!].DeletionPolicy).toBe('Delete');
+    });
+  });
+
+  describe('CloudFront Distribution', () => {
+    it('creates a CloudFront distribution', () => {
+      template.resourceCountIs('AWS::CloudFront::Distribution', 1);
+    });
+
+    it('sets default root object to index.html', () => {
+      template.hasResourceProperties('AWS::CloudFront::Distribution', {
+        DistributionConfig: {
+          DefaultRootObject: 'index.html',
+        },
+      });
+    });
+
+    it('redirects HTTP to HTTPS', () => {
+      template.hasResourceProperties('AWS::CloudFront::Distribution', {
+        DistributionConfig: {
+          DefaultCacheBehavior: Match.objectLike({
+            ViewerProtocolPolicy: 'redirect-to-https',
+          }),
+        },
+      });
+    });
+
+    it('uses PriceClass_100 (cheapest — NA and EU only)', () => {
+      template.hasResourceProperties('AWS::CloudFront::Distribution', {
+        DistributionConfig: {
+          PriceClass: 'PriceClass_100',
+        },
+      });
+    });
+
+    it('configures custom error response for 403 to redirect to /index.html with 200', () => {
+      template.hasResourceProperties('AWS::CloudFront::Distribution', {
+        DistributionConfig: {
+          CustomErrorResponses: Match.arrayWith([
+            Match.objectLike({
+              ErrorCode: 403,
+              ResponseCode: 200,
+              ResponsePagePath: '/index.html',
+            }),
+          ]),
+        },
+      });
+    });
+
+    it('configures custom error response for 404 to redirect to /index.html with 200', () => {
+      template.hasResourceProperties('AWS::CloudFront::Distribution', {
+        DistributionConfig: {
+          CustomErrorResponses: Match.arrayWith([
+            Match.objectLike({
+              ErrorCode: 404,
+              ResponseCode: 200,
+              ResponsePagePath: '/index.html',
+            }),
+          ]),
+        },
+      });
+    });
+
+    it('uses the S3 bucket as origin', () => {
+      template.hasResourceProperties('AWS::CloudFront::Distribution', {
+        DistributionConfig: {
+          Origins: Match.arrayWith([
+            Match.objectLike({
+              DomainName: Match.anyValue(),
+              S3OriginConfig: Match.objectLike({
+                OriginAccessIdentity: '',
+              }),
+            }),
+          ]),
+        },
+      });
+    });
+
+    it('references the OAC in the distribution origin', () => {
+      template.hasResourceProperties('AWS::CloudFront::Distribution', {
+        DistributionConfig: {
+          Origins: Match.arrayWith([
+            Match.objectLike({
+              OriginAccessControlId: Match.anyValue(),
+            }),
+          ]),
+        },
+      });
+    });
+  });
+
+  describe('Origin Access Control (OAC)', () => {
+    it('creates a CloudFront Origin Access Control resource', () => {
+      template.resourceCountIs('AWS::CloudFront::OriginAccessControl', 1);
+    });
+
+    it('configures OAC for S3 with sigv4 signing', () => {
+      template.hasResourceProperties('AWS::CloudFront::OriginAccessControl', {
+        OriginAccessControlConfig: Match.objectLike({
+          OriginAccessControlOriginType: 's3',
+          SigningBehavior: 'always',
+          SigningProtocol: 'sigv4',
+        }),
+      });
+    });
+  });
+
+  describe('Bucket Policy', () => {
+    it('creates a bucket policy granting CloudFront access via s3:GetObject', () => {
+      template.hasResourceProperties('AWS::S3::BucketPolicy', {
+        PolicyDocument: {
+          Statement: Match.arrayWith([
+            Match.objectLike({
+              Action: 's3:GetObject',
+              Effect: 'Allow',
+              Principal: {
+                Service: 'cloudfront.amazonaws.com',
+              },
+            }),
+          ]),
+        },
+      });
+    });
+  });
+
+  describe('Stack Outputs', () => {
+    it('outputs the frontend bucket name', () => {
+      template.hasOutput('FrontendBucketName', {
+        Value: Match.anyValue(),
+      });
+    });
+
+    it('outputs the distribution ID', () => {
+      template.hasOutput('DistributionId', {
+        Value: Match.anyValue(),
+      });
+    });
+
+    it('outputs the distribution domain name', () => {
+      template.hasOutput('DistributionDomainName', {
+        Value: Match.anyValue(),
+      });
+    });
+  });
+
+  describe('Stack Properties', () => {
+    it('exposes the frontend bucket as a public readonly property', () => {
+      expect(stack.frontendBucket).toBeDefined();
+      expect(stack.frontendBucket.bucketName).toBeDefined();
+    });
+
+    it('exposes the distribution as a public readonly property', () => {
+      expect(stack.distribution).toBeDefined();
+      expect(stack.distribution.distributionId).toBeDefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- **#33**: Full HostingStack with S3 bucket (private, versioned) + CloudFront distribution
- Origin Access Control (OAC, not legacy OAI) for secure S3 access
- SPA routing via custom error responses (403/404 → /index.html)
- HTTPS-only, PriceClass_100, stack outputs for deploy pipeline

## Test plan
- [ ] 19 new CDK assertion tests (S3, CloudFront, OAC, bucket policy, outputs)
- [ ] All 62 infra tests pass
- [ ] Verify `cdk synth` produces valid CloudFormation template

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)