### PR TITLE
fix: add defense-in-depth auth enforcement for all API endpoints

### DIFF
--- a/api/test/handlers/expenses/list.test.ts
+++ b/api/test/handlers/expenses/list.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { APIGatewayProxyEventV2 } from 'aws-lambda';
 import type { AuthResult, AuthContext } from '../../../src/middleware/auth.js';
+import { extractAuthContext } from '../../../src/middleware/auth.js';
 import type { ExpenseRepository } from '../../../src/lib/dynamo.js';
 import type { Expense, AbleCategory, ApiError } from '../../../src/lib/types.js';
 import { createListExpensesHandler } from '../../../src/handlers/expenses/list.js';
@@ -409,6 +410,84 @@ describe('createListExpensesHandler', () => {
       expect(result.headers).toEqual(
         expect.objectContaining({ 'content-type': 'application/json' }),
       );
+    });
+  });
+
+  describe('defense-in-depth: extractAuthContext with API Gateway authorizer (#63)', () => {
+    /**
+     * Build event with API Gateway JWT authorizer context for defense-in-depth tests.
+     */
+    function makeEventWithAuthorizer(
+      queryStringParameters: Record<string, string> | undefined,
+      claims: Record<string, string> | undefined,
+    ): APIGatewayProxyEventV2 {
+      const event = makeEvent(queryStringParameters);
+      if (claims) {
+        (event.requestContext as Record<string, unknown>)['authorizer'] = {
+          jwt: { claims, scopes: [] },
+        };
+      } else {
+        (event.requestContext as Record<string, unknown>)['authorizer'] = undefined;
+      }
+      return event;
+    }
+
+    it('returns 401 when authorizer context is missing and extractAuthContext is used', async () => {
+      const handler = createListExpensesHandler({
+        repo: mockRepo as unknown as ExpenseRepository,
+        authenticate: (event: APIGatewayProxyEventV2) => Promise.resolve(extractAuthContext(event)),
+      });
+
+      const event = makeEventWithAuthorizer(undefined, undefined);
+      const result = await handler(event);
+
+      expect(result.statusCode).toBe(401);
+      const responseBody = JSON.parse(result.body as string) as { message: string };
+      expect(responseBody.message).toBe('Unauthorized');
+      expect(mockRepo.listExpenses).not.toHaveBeenCalled();
+      expect(mockRepo.listExpensesByCategory).not.toHaveBeenCalled();
+    });
+
+    it('returns 401 when JWT claims have invalid role via extractAuthContext', async () => {
+      const handler = createListExpensesHandler({
+        repo: mockRepo as unknown as ExpenseRepository,
+        authenticate: (event: APIGatewayProxyEventV2) => Promise.resolve(extractAuthContext(event)),
+      });
+
+      const claims = {
+        sub: 'user-alice-sub',
+        email: 'alice@example.com',
+        'custom:accountId': 'acct_01HXYZ',
+        'custom:displayName': 'Alice Smith',
+        'custom:role': 'admin',
+      };
+      const event = makeEventWithAuthorizer(undefined, claims);
+      const result = await handler(event);
+
+      expect(result.statusCode).toBe(401);
+      expect(mockRepo.listExpenses).not.toHaveBeenCalled();
+    });
+
+    it('succeeds when valid authorizer context is present via extractAuthContext', async () => {
+      mockRepo.listExpenses.mockResolvedValue([]);
+
+      const handler = createListExpensesHandler({
+        repo: mockRepo as unknown as ExpenseRepository,
+        authenticate: (event: APIGatewayProxyEventV2) => Promise.resolve(extractAuthContext(event)),
+      });
+
+      const claims = {
+        sub: 'user-alice-sub',
+        email: 'alice@example.com',
+        'custom:accountId': 'acct_01HXYZ',
+        'custom:displayName': 'Alice Smith',
+        'custom:role': 'owner',
+      };
+      const event = makeEventWithAuthorizer(undefined, claims);
+      const result = await handler(event);
+
+      expect(result.statusCode).toBe(200);
+      expect(mockRepo.listExpenses).toHaveBeenCalledWith('acct_01HXYZ');
     });
   });
 });


### PR DESCRIPTION
## Summary

Closes #63

- Added `extractAuthContext` function to `api/src/middleware/auth.ts` that validates API Gateway JWT authorizer context (`event.requestContext.authorizer.jwt.claims`) at the Lambda handler level
- Validates all required claims exist and are non-empty: `sub`, `email`, `custom:accountId`, `custom:role`
- Validates role is a recognized value (`owner` or `authorized_rep`)
- Returns `{ statusCode: 401, body: JSON.stringify({ message: 'Unauthorized' }) }` if any validation fails
- Provides defense-in-depth alongside the API Gateway Cognito User Pool Authorizer

## Test plan

- [x] 16 new unit tests for `extractAuthContext` in `auth.test.ts` covering:
  - Successful extraction with valid claims
  - Missing authorizer context returns 401
  - Missing/empty JWT claims returns 401
  - Missing/empty required claims (sub, email, accountId, role) returns 401
  - Invalid role value returns 401
  - Response format verification (content-type, no claim leakage)
- [x] 3 new tests per handler (15 total) across create, get, list, upload, categorize:
  - Returns 401 when authorizer context missing via `extractAuthContext`
  - Returns 401 when JWT claims incomplete via `extractAuthContext`
  - Succeeds when valid authorizer context present via `extractAuthContext`
- [x] All 131 original tests still pass (162 total)
- [x] TypeScript strict compilation clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)