### PR TITLE
chore: make UAT demo script with screenshots mandatory

### DIFF
--- a/.claude/agents/scrum-master.md
+++ b/.claude/agents/scrum-master.md
@@ -37,11 +37,22 @@ Before any implementation is committed, the following reviews MUST pass:
 3. Both agents report findings. Any CRITICAL or HIGH issues block the commit until resolved.
 4. Only after both agents approve does the work proceed to commit.
 
+### Sprint-End UAT Review (MANDATORY)
+Before the sprint is considered releasable, the UAT Tester MUST:
+1. Review ALL completed stories from the user's perspective
+2. Update the **product demo script** (`docs/demos/product-demo.md`) with screenshots of all implemented features
+3. Run demo scripts against the deployed application
+4. Submit a Sprint UAT Report to the Product Owner
+5. Product Owner triages findings — blockers must be fixed before release
+
+This step CANNOT be skipped. A sprint without UAT review is not complete.
+
 ### Sprint Review
 1. Collect completed work from all agents
 2. Verify Definition of Done checklist for each issue
-3. Run UAT demo scripts to confirm acceptance
-4. Close completed issues
+3. Confirm UAT Tester has submitted the Sprint UAT Report
+4. Product Owner has triaged all UAT findings (blockers resolved, others backlogged)
+5. Close completed issues
 
 ### Retrospective
 1. What went well?

--- a/.claude/agents/uat-tester.md
+++ b/.claude/agents/uat-tester.md
@@ -49,7 +49,49 @@ Keep these personas in mind when testing:
 - [ ] [Edge case and expected behavior]
 ```
 
+## Product Demo Script (MANDATORY)
+
+You are responsible for maintaining a **living demo script** at `docs/demos/product-demo.md` that demonstrates the entire product end-to-end. This is your most important deliverable.
+
+### Requirements
+
+- The demo script MUST cover every user-facing feature that is currently implemented
+- Each step MUST include a **screenshot** captured from the running application (use the browser or a screenshot tool)
+- Screenshots go in `docs/demos/screenshots/` with descriptive filenames (e.g., `01-login-page.png`, `02-empty-dashboard.png`)
+- The demo script is updated **every sprint** to reflect newly completed stories
+- Anyone (investors, contributors, users) should be able to follow the demo script and understand the full product
+- The demo script doubles as the canonical "what does this product do?" document
+
+### Demo Script Structure
+
+```markdown
+# ABLE Tracker — Product Demo
+
+> Last updated: Sprint [N], [date]
+
+## What is ABLE Tracker?
+[1-2 sentence overview for someone who has never seen the product]
+
+## Demo Walkthrough
+
+### 1. Login
+![Login page](screenshots/01-login-page.png)
+[Step-by-step instructions]
+
+### 2. Dashboard
+![Dashboard](screenshots/02-dashboard.png)
+[What the user sees, what it means]
+
+### 3. Add an Expense
+![Expense form](screenshots/03-expense-form.png)
+[Walk through filling out the form]
+
+... (one section per feature)
+```
+
 ## Core Demo Scripts to Maintain
+
+In addition to the product demo, maintain individual demo scripts for detailed testing:
 
 1. **Onboarding**: New user signs up → sees empty dashboard → understands what to do next
 2. **Add Expense**: Log an out-of-pocket expense → upload receipt → AI categorizes → confirm/override

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,7 +142,7 @@ This project uses a 12-agent team. See `.claude/agents/` for individual agent de
 | Backend Engineer | Lambda handlers, DynamoDB, Claude integration | `api/` |
 | DevOps Engineer | CDK infrastructure, CI/CD pipelines | `infra/`, `.github/workflows/` |
 | QA Engineer | Test strategy, coverage, **pre-commit review gate** | `**/test/`, test utilities |
-| UAT Tester | User advocacy, demo scripts, acceptance testing | `docs/demos/`, acceptance criteria verification |
+| UAT Tester | User advocacy, **product demo script with screenshots**, acceptance testing | `docs/demos/`, `docs/demos/screenshots/`, acceptance criteria verification |
 | Security Reviewer | Auth, data protection, IAM, PII, **pre-commit review gate** | Security-sensitive code across all packages |
 | Technical Writer | Documentation quality and completeness | `docs/`, `README.md`, inline docs |
 | Code Reviewer | Engineering standards enforcement | PR reviews, code quality gates |
@@ -156,7 +156,7 @@ This project uses a 12-agent team. See `.claude/agents/` for individual agent de
 2. **Architecture Planning** (L/XL only): Senior Architect produces implementation plan (API contracts, data model, component breakdown, test strategy). Architect does NOT implement.
 3. **Development**: Implementing agents work on assigned issues following TDD. Backend and Frontend can work in parallel on agreed interfaces.
 4. **Pre-Commit Review Gate**: Before any implementation is committed, **both** Security Reviewer and QA Engineer must review and approve. CRITICAL/HIGH findings block the commit.
-5. **Sprint-End UAT Review**: UAT Tester reviews ALL completed stories from the user's perspective and submits a Sprint UAT Report. Accessibility Engineer verifies UI stories.
+5. **Sprint-End UAT Review** (MANDATORY — cannot be skipped): UAT Tester reviews ALL completed stories from the user's perspective, **updates the product demo script** (`docs/demos/product-demo.md`) **with screenshots of all implemented features**, and submits a Sprint UAT Report. Accessibility Engineer verifies UI stories.
 6. **Product Owner Triage**: Product Owner triages UAT findings — **blockers** must be fixed before sprint release, other findings go to backlog.
 7. **Retrospective**: Scrum Master facilitates. What worked? What didn't? Improve the process.
 


### PR DESCRIPTION
## Summary

Strengthens the UAT Tester's responsibilities and ensures UAT is called every sprint:

- **UAT Tester agent**: Added explicit "Product Demo Script (MANDATORY)" section requiring a living demo script at `docs/demos/product-demo.md` with screenshots of every implemented feature, updated every sprint
- **Scrum Master agent**: Added "Sprint-End UAT Review (MANDATORY)" step that cannot be skipped — includes demo script update, screenshots, Sprint UAT Report
- **CLAUDE.md**: Reinforced UAT review as mandatory in sprint workflow, added screenshots requirement

## Test plan

- [x] No code changes — agent definition and workflow documentation only
- [x] All 399 tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)