### PR TITLE
fix: remove 5-record limit from reimbursements table (#100)

### DIFF
--- a/web/src/pages/Reimbursements.tsx
+++ b/web/src/pages/Reimbursements.tsx
@@ -68,8 +68,7 @@ export function Reimbursements() {
   const totalUnreimbursed = reimbursements.reduce((sum, r) => sum + r.totalOwed, 0);
   const unreimbursedExpenses = [...expenses]
     .filter((e) => !e.reimbursed)
-    .sort((a, b) => b.date.localeCompare(a.date))
-    .slice(0, 5);
+    .sort((a, b) => b.date.localeCompare(a.date));
   const allReimbursed = expenses.length > 0 && reimbursements.length === 0;
 
   return (


### PR DESCRIPTION
## Summary
- Remove `.slice(0, 5)` from unreimbursed expenses list on Reimbursements page
- All unreimbursed expenses now display in the table, matching the Total Unreimbursed header

Closes #100

## Test plan
- [x] All 211 web tests pass
- [ ] Verify all unreimbursed expenses appear in table (no truncation)
- [ ] Verify table row amounts sum to the Total Unreimbursed header

🤖 Generated with [Claude Code](https://claude.com/claude-code)