### PR TITLE
fix: add fileSize to smoke test upload URL request

### DIFF
--- a/scripts/smoke-test.mjs
+++ b/scripts/smoke-test.mjs
@@ -299,6 +299,7 @@ async function testRequestUploadUrl(token) {
       body: {
         fileName: 'smoke-test-receipt.png',
         contentType: 'image/png',
+        fileSize: 1024, // 1 KB test file
       },
     });
     const passed = status === 200 && body && typeof body.uploadUrl === 'string';


### PR DESCRIPTION
## Summary
- Adds the required `fileSize` field to the `testRequestUploadUrl` function in `scripts/smoke-test.mjs`
- After PR #103 added upload size validation, the `POST /uploads/request-url` endpoint requires `fileSize` in the request body
- Without this field, the smoke test fails with a validation error

Fixes #111

## Changes
- Added `fileSize: 1024` (1 KB test file) to the request body in `testRequestUploadUrl`

## Test plan
- [x] All existing tests pass (209 API, 15 infra, 63 web)
- [ ] Run smoke test against deployed environment to verify the upload URL endpoint returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)