### PR TITLE
feat: add bulk reimbursement API endpoint (#109)

### DIFF
--- a/api/src/handlers/expenses/reimburse-bulk.handler.ts
+++ b/api/src/handlers/expenses/reimburse-bulk.handler.ts
@@ -1,0 +1,18 @@
+/**
+ * Lambda entry point for POST /expenses/reimburse-bulk.
+ * Wires up real AWS dependencies and exports the handler.
+ */
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
+import { ExpenseRepository } from '../../lib/dynamo.js';
+import { extractAuthContext } from '../../middleware/auth.js';
+import { createReimburseBulkHandler } from './reimburse-bulk.js';
+
+const ddbClient = new DynamoDBClient({});
+const docClient = DynamoDBDocumentClient.from(ddbClient);
+const repo = new ExpenseRepository(docClient, process.env['TABLE_NAME']!);
+
+export const handler = createReimburseBulkHandler({
+  repo,
+  authenticate: async (event) => extractAuthContext(event),
+});

--- a/api/src/handlers/expenses/reimburse-bulk.ts
+++ b/api/src/handlers/expenses/reimburse-bulk.ts
@@ -1,0 +1,151 @@
+import type { APIGatewayProxyEventV2, APIGatewayProxyResultV2 } from 'aws-lambda';
+import type { ExpenseRepository } from '../../lib/dynamo.js';
+import type { AuthResult } from '../../middleware/auth.js';
+import type { ApiError, BulkReimburseResponse } from '../../lib/types.js';
+import { createLogger, extractRequestId } from '../../lib/logger.js';
+
+export interface ReimburseBulkHandlerDeps {
+  repo: ExpenseRepository;
+  authenticate: (event: APIGatewayProxyEventV2) => Promise<AuthResult>;
+}
+
+const MAX_EXPENSE_IDS = 100;
+const MAX_REIMBURSED_BY_LENGTH = 200;
+
+function errorResponse(statusCode: number, error: string, code: string, details?: unknown): APIGatewayProxyResultV2 {
+  const body: ApiError = { error, code };
+  if (details !== undefined) {
+    body.details = details;
+  }
+  return {
+    statusCode,
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  };
+}
+
+function jsonResponse(statusCode: number, data: unknown): APIGatewayProxyResultV2 {
+  return {
+    statusCode,
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(data),
+  };
+}
+
+function parseBody(event: APIGatewayProxyEventV2): Record<string, unknown> | null {
+  if (!event.body) {
+    return null;
+  }
+
+  try {
+    const parsed: unknown = JSON.parse(event.body);
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+      return null;
+    }
+    return parsed as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+export function createReimburseBulkHandler(deps: ReimburseBulkHandlerDeps) {
+  const log = createLogger('ReimburseBulk');
+
+  return async (event: APIGatewayProxyEventV2): Promise<APIGatewayProxyResultV2> => {
+    const requestId = extractRequestId(event as unknown as Record<string, unknown>);
+    log.info('Request started', requestId);
+
+    // 1. Authenticate
+    const authResult = await deps.authenticate(event);
+    if (!authResult.success) {
+      log.warn('Authentication failed', requestId);
+      return authResult.response;
+    }
+    const { context } = authResult;
+
+    // 2. Parse and validate request body
+    const body = parseBody(event);
+    if (body === null) {
+      log.warn('Invalid JSON body', requestId);
+      return errorResponse(400, 'Request body must be valid JSON', 'INVALID_JSON');
+    }
+
+    // Validate expenseIds
+    const rawIds = body['expenseIds'];
+    if (!Array.isArray(rawIds) || rawIds.length === 0) {
+      log.warn('Invalid expenseIds', requestId);
+      return errorResponse(400, 'expenseIds must be a non-empty array', 'VALIDATION_ERROR');
+    }
+
+    if (rawIds.length > MAX_EXPENSE_IDS) {
+      log.warn('Too many expenseIds', requestId, { count: rawIds.length });
+      return errorResponse(400, `expenseIds must not exceed ${MAX_EXPENSE_IDS} items`, 'VALIDATION_ERROR');
+    }
+
+    const expenseIds = rawIds as string[];
+
+    // Validate reimbursedBy
+    if (typeof body['reimbursedBy'] !== 'string' || body['reimbursedBy'].trim().length === 0) {
+      log.warn('Missing reimbursedBy', requestId);
+      return errorResponse(400, 'reimbursedBy is required', 'VALIDATION_ERROR');
+    }
+
+    const reimbursedBy = body['reimbursedBy'] as string;
+
+    if (reimbursedBy.length > MAX_REIMBURSED_BY_LENGTH) {
+      log.warn('reimbursedBy too long', requestId);
+      return errorResponse(400, `reimbursedBy must not exceed ${MAX_REIMBURSED_BY_LENGTH} characters`, 'VALIDATION_ERROR');
+    }
+
+    try {
+      // 3. Fetch all expenses and validate state
+      const expenses = await Promise.all(
+        expenseIds.map((id) => deps.repo.getExpense(context.accountId, id)),
+      );
+
+      // Check for not found
+      const notFoundIds: string[] = [];
+      for (let i = 0; i < expenseIds.length; i++) {
+        if (expenses[i] === null) {
+          notFoundIds.push(expenseIds[i]);
+        }
+      }
+
+      if (notFoundIds.length > 0) {
+        log.info('Expenses not found', requestId, { statusCode: 404, notFoundIds });
+        return errorResponse(404, 'One or more expenses not found', 'NOT_FOUND', { notFoundIds });
+      }
+
+      // Check for already reimbursed
+      const alreadyReimbursedIds: string[] = [];
+      for (let i = 0; i < expenseIds.length; i++) {
+        if (expenses[i]!.reimbursed) {
+          alreadyReimbursedIds.push(expenseIds[i]);
+        }
+      }
+
+      if (alreadyReimbursedIds.length > 0) {
+        log.warn('Expenses already reimbursed', requestId, { alreadyReimbursedIds });
+        return errorResponse(409, 'One or more expenses are already reimbursed', 'ALREADY_REIMBURSED', { alreadyReimbursedIds });
+      }
+
+      // 4. Bulk mark as reimbursed
+      const validExpenses = expenses.filter((e): e is NonNullable<typeof e> => e !== null);
+      const updated = await deps.repo.markReimbursedBulk(context.accountId, validExpenses);
+
+      // 5. Return response
+      const response: BulkReimburseResponse = {
+        expenses: updated,
+        count: updated.length,
+      };
+
+      log.info('Request completed', requestId, { statusCode: 200, count: updated.length });
+      return jsonResponse(200, response);
+    } catch (err: unknown) {
+      const errorName = err instanceof Error ? err.name : 'UnknownError';
+      const errorMessage = err instanceof Error ? err.message : String(err);
+      log.error('Failed to bulk reimburse expenses', requestId, { errorName, errorMessage });
+      throw err;
+    }
+  };
+}

--- a/api/src/lib/dynamo.ts
+++ b/api/src/lib/dynamo.ts
@@ -4,6 +4,7 @@ import {
   QueryCommand,
   UpdateCommand,
   DeleteCommand,
+  TransactWriteCommand,
 } from '@aws-sdk/lib-dynamodb';
 import { ulid } from 'ulid';
 import type { AbleCategory, CreateExpenseInput, Expense, ListExpensesFilters } from './types.js';
@@ -218,6 +219,48 @@ export class ExpenseRepository {
     );
 
     return itemToExpense(result.Attributes as Record<string, unknown>);
+  }
+
+  /**
+   * Mark multiple expenses as reimbursed atomically using DynamoDB transactions.
+   * Each item has a condition expression to prevent double-reimbursement.
+   * If any expense is already reimbursed, the entire transaction aborts.
+   */
+  async markReimbursedBulk(accountId: string, expenses: Expense[]): Promise<Expense[]> {
+    const now = new Date().toISOString();
+
+    const transactItems = expenses.map((expense) => ({
+      Update: {
+        TableName: this.tableName,
+        Key: {
+          PK: `ACCOUNT#${accountId}`,
+          SK: `EXP#${expense.date}#${expense.expenseId}`,
+        },
+        ConditionExpression: 'reimbursed = :false',
+        UpdateExpression: 'SET reimbursed = :reimbursed, reimbursedAt = :reimbursedAt, updatedAt = :updatedAt, #gsi2sk = :gsi2sk',
+        ExpressionAttributeNames: {
+          '#gsi2sk': 'GSI2SK',
+        },
+        ExpressionAttributeValues: {
+          ':false': false,
+          ':reimbursed': true,
+          ':reimbursedAt': now,
+          ':updatedAt': now,
+          ':gsi2sk': `PAID#${expense.paidBy}#1#${expense.date}`,
+        },
+      },
+    }));
+
+    await this.client.send(
+      new TransactWriteCommand({ TransactItems: transactItems }),
+    );
+
+    return expenses.map((expense) => ({
+      ...expense,
+      reimbursed: true,
+      reimbursedAt: now,
+      updatedAt: now,
+    }));
   }
 
   /**

--- a/api/src/lib/types.ts
+++ b/api/src/lib/types.ts
@@ -83,6 +83,16 @@ export interface ListExpensesFilters {
   reimbursed?: boolean;
 }
 
+export interface BulkReimburseRequest {
+  expenseIds: string[]; // 1-100 items
+  reimbursedBy: string;
+}
+
+export interface BulkReimburseResponse {
+  expenses: Expense[];
+  count: number;
+}
+
 export interface ApiError {
   error: string;
   code: string;

--- a/api/test/handlers/expenses/reimburse-bulk.test.ts
+++ b/api/test/handlers/expenses/reimburse-bulk.test.ts
@@ -1,0 +1,403 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { APIGatewayProxyEventV2 } from 'aws-lambda';
+import type { AuthResult, AuthContext } from '../../../src/middleware/auth.js';
+import type { ExpenseRepository } from '../../../src/lib/dynamo.js';
+import type { Expense, ApiError, BulkReimburseResponse } from '../../../src/lib/types.js';
+import { createReimburseBulkHandler } from '../../../src/handlers/expenses/reimburse-bulk.js';
+
+const mockAuthContext: AuthContext = {
+  userId: 'user-alice-sub',
+  accountId: 'acct_01HXYZ',
+  email: 'alice@example.com',
+  displayName: 'Alice Smith',
+  role: 'owner',
+};
+
+function makeEvent(body: string | undefined): APIGatewayProxyEventV2 {
+  return {
+    version: '2.0',
+    routeKey: 'POST /expenses/reimburse-bulk',
+    rawPath: '/expenses/reimburse-bulk',
+    rawQueryString: '',
+    headers: {
+      'content-type': 'application/json',
+      authorization: 'Bearer valid-token',
+    },
+    requestContext: {
+      accountId: '123456789012',
+      apiId: 'api-id',
+      domainName: 'test.execute-api.us-east-1.amazonaws.com',
+      domainPrefix: 'test',
+      http: {
+        method: 'POST',
+        path: '/expenses/reimburse-bulk',
+        protocol: 'HTTP/1.1',
+        sourceIp: '127.0.0.1',
+        userAgent: 'test-agent',
+      },
+      requestId: 'request-id',
+      routeKey: 'POST /expenses/reimburse-bulk',
+      stage: '$default',
+      time: '15/Mar/2025:00:00:00 +0000',
+      timeEpoch: 1742169600000,
+    },
+    isBase64Encoded: false,
+    body,
+  };
+}
+
+function makeUnreimbursedExpense(overrides: Partial<Expense> = {}): Expense {
+  return {
+    expenseId: 'EXP_01HTEST',
+    accountId: 'acct_01HXYZ',
+    date: '2025-03-10',
+    vendor: 'Walgreens',
+    description: 'Medication co-pay',
+    amount: 2499,
+    category: 'Health, prevention & wellness',
+    categoryConfidence: 'ai_confirmed',
+    categoryNotes: 'Over-the-counter medication',
+    receiptKey: 'receipts/acct_01HXYZ/receipt-001.jpg',
+    submittedBy: 'user-alice-sub',
+    paidBy: 'user-bob-sub',
+    reimbursed: false,
+    reimbursedAt: null,
+    createdAt: '2025-03-10T10:00:00.000Z',
+    updatedAt: '2025-03-10T10:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function makeReimbursedExpense(overrides: Partial<Expense> = {}): Expense {
+  return {
+    ...makeUnreimbursedExpense(),
+    reimbursed: true,
+    reimbursedAt: '2025-03-15T10:00:00.000Z',
+    updatedAt: '2025-03-15T10:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('createReimburseBulkHandler', () => {
+  let mockRepo: {
+    getExpense: ReturnType<typeof vi.fn>;
+    markReimbursedBulk: ReturnType<typeof vi.fn>;
+  };
+  let mockAuthenticate: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2025-03-15T10:00:00.000Z'));
+
+    mockRepo = {
+      getExpense: vi.fn(),
+      markReimbursedBulk: vi.fn(),
+    };
+
+    mockAuthenticate = vi.fn<(event: APIGatewayProxyEventV2) => Promise<AuthResult>>();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('authentication', () => {
+    it('returns 401 when auth middleware fails', async () => {
+      mockAuthenticate.mockResolvedValue({
+        success: false,
+        response: {
+          statusCode: 401,
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ error: 'Missing Authorization header', code: 'UNAUTHORIZED' }),
+        },
+      });
+
+      const handler = createReimburseBulkHandler({
+        repo: mockRepo as unknown as ExpenseRepository,
+        authenticate: mockAuthenticate,
+      });
+
+      const event = makeEvent(JSON.stringify({ expenseIds: ['EXP_A'], reimbursedBy: 'Alice' }));
+      const result = await handler(event);
+
+      expect(result.statusCode).toBe(401);
+      expect(mockRepo.getExpense).not.toHaveBeenCalled();
+      expect(mockRepo.markReimbursedBulk).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('validation', () => {
+    beforeEach(() => {
+      mockAuthenticate.mockResolvedValue({ success: true, context: mockAuthContext });
+    });
+
+    it('returns 400 if request body is missing', async () => {
+      const handler = createReimburseBulkHandler({
+        repo: mockRepo as unknown as ExpenseRepository,
+        authenticate: mockAuthenticate,
+      });
+
+      const event = makeEvent(undefined);
+      const result = await handler(event);
+
+      expect(result.statusCode).toBe(400);
+      const responseBody = JSON.parse(result.body as string) as ApiError;
+      expect(responseBody.code).toBe('INVALID_JSON');
+    });
+
+    it('returns 400 if request body is invalid JSON', async () => {
+      const handler = createReimburseBulkHandler({
+        repo: mockRepo as unknown as ExpenseRepository,
+        authenticate: mockAuthenticate,
+      });
+
+      const event = makeEvent('{ not valid }}}');
+      const result = await handler(event);
+
+      expect(result.statusCode).toBe(400);
+      const responseBody = JSON.parse(result.body as string) as ApiError;
+      expect(responseBody.code).toBe('INVALID_JSON');
+    });
+
+    it('returns 400 if expenseIds is missing', async () => {
+      const handler = createReimburseBulkHandler({
+        repo: mockRepo as unknown as ExpenseRepository,
+        authenticate: mockAuthenticate,
+      });
+
+      const event = makeEvent(JSON.stringify({ reimbursedBy: 'Alice' }));
+      const result = await handler(event);
+
+      expect(result.statusCode).toBe(400);
+      const responseBody = JSON.parse(result.body as string) as ApiError;
+      expect(responseBody.code).toBe('VALIDATION_ERROR');
+      expect(responseBody.error).toMatch(/expenseIds/i);
+    });
+
+    it('returns 400 if expenseIds is not an array', async () => {
+      const handler = createReimburseBulkHandler({
+        repo: mockRepo as unknown as ExpenseRepository,
+        authenticate: mockAuthenticate,
+      });
+
+      const event = makeEvent(JSON.stringify({ expenseIds: 'not-array', reimbursedBy: 'Alice' }));
+      const result = await handler(event);
+
+      expect(result.statusCode).toBe(400);
+      const responseBody = JSON.parse(result.body as string) as ApiError;
+      expect(responseBody.code).toBe('VALIDATION_ERROR');
+      expect(responseBody.error).toMatch(/expenseIds/i);
+    });
+
+    it('returns 400 if expenseIds is empty', async () => {
+      const handler = createReimburseBulkHandler({
+        repo: mockRepo as unknown as ExpenseRepository,
+        authenticate: mockAuthenticate,
+      });
+
+      const event = makeEvent(JSON.stringify({ expenseIds: [], reimbursedBy: 'Alice' }));
+      const result = await handler(event);
+
+      expect(result.statusCode).toBe(400);
+      const responseBody = JSON.parse(result.body as string) as ApiError;
+      expect(responseBody.code).toBe('VALIDATION_ERROR');
+      expect(responseBody.error).toMatch(/expenseIds/i);
+    });
+
+    it('returns 400 if expenseIds has more than 100 items', async () => {
+      const handler = createReimburseBulkHandler({
+        repo: mockRepo as unknown as ExpenseRepository,
+        authenticate: mockAuthenticate,
+      });
+
+      const ids = Array.from({ length: 101 }, (_, i) => `EXP_${i}`);
+      const event = makeEvent(JSON.stringify({ expenseIds: ids, reimbursedBy: 'Alice' }));
+      const result = await handler(event);
+
+      expect(result.statusCode).toBe(400);
+      const responseBody = JSON.parse(result.body as string) as ApiError;
+      expect(responseBody.code).toBe('VALIDATION_ERROR');
+      expect(responseBody.error).toMatch(/100/);
+    });
+
+    it('returns 400 if reimbursedBy is missing', async () => {
+      const handler = createReimburseBulkHandler({
+        repo: mockRepo as unknown as ExpenseRepository,
+        authenticate: mockAuthenticate,
+      });
+
+      const event = makeEvent(JSON.stringify({ expenseIds: ['EXP_A'] }));
+      const result = await handler(event);
+
+      expect(result.statusCode).toBe(400);
+      const responseBody = JSON.parse(result.body as string) as ApiError;
+      expect(responseBody.code).toBe('VALIDATION_ERROR');
+      expect(responseBody.error).toMatch(/reimbursedBy/i);
+    });
+
+    it('returns 400 if reimbursedBy is empty string', async () => {
+      const handler = createReimburseBulkHandler({
+        repo: mockRepo as unknown as ExpenseRepository,
+        authenticate: mockAuthenticate,
+      });
+
+      const event = makeEvent(JSON.stringify({ expenseIds: ['EXP_A'], reimbursedBy: '' }));
+      const result = await handler(event);
+
+      expect(result.statusCode).toBe(400);
+      const responseBody = JSON.parse(result.body as string) as ApiError;
+      expect(responseBody.code).toBe('VALIDATION_ERROR');
+      expect(responseBody.error).toMatch(/reimbursedBy/i);
+    });
+
+    it('returns 400 if reimbursedBy exceeds 200 characters', async () => {
+      const handler = createReimburseBulkHandler({
+        repo: mockRepo as unknown as ExpenseRepository,
+        authenticate: mockAuthenticate,
+      });
+
+      const event = makeEvent(JSON.stringify({ expenseIds: ['EXP_A'], reimbursedBy: 'A'.repeat(201) }));
+      const result = await handler(event);
+
+      expect(result.statusCode).toBe(400);
+      const responseBody = JSON.parse(result.body as string) as ApiError;
+      expect(responseBody.code).toBe('VALIDATION_ERROR');
+      expect(responseBody.error).toMatch(/200/);
+    });
+
+    it('accepts exactly 100 expense IDs', async () => {
+      const ids = Array.from({ length: 100 }, (_, i) => `EXP_${i}`);
+      const expenses = ids.map((id) => makeUnreimbursedExpense({ expenseId: id }));
+      const reimbursedExpenses = ids.map((id) => makeReimbursedExpense({ expenseId: id }));
+
+      mockAuthenticate.mockResolvedValue({ success: true, context: mockAuthContext });
+      for (let i = 0; i < 100; i++) {
+        mockRepo.getExpense.mockResolvedValueOnce(expenses[i]);
+      }
+      mockRepo.markReimbursedBulk.mockResolvedValue(reimbursedExpenses);
+
+      const handler = createReimburseBulkHandler({
+        repo: mockRepo as unknown as ExpenseRepository,
+        authenticate: mockAuthenticate,
+      });
+
+      const event = makeEvent(JSON.stringify({ expenseIds: ids, reimbursedBy: 'Alice' }));
+      const result = await handler(event);
+
+      expect(result.statusCode).toBe(200);
+    });
+  });
+
+  describe('expense not found', () => {
+    it('returns 404 when any expense ID does not exist', async () => {
+      mockAuthenticate.mockResolvedValue({ success: true, context: mockAuthContext });
+      mockRepo.getExpense.mockResolvedValueOnce(makeUnreimbursedExpense({ expenseId: 'EXP_A' }));
+      mockRepo.getExpense.mockResolvedValueOnce(null);
+
+      const handler = createReimburseBulkHandler({
+        repo: mockRepo as unknown as ExpenseRepository,
+        authenticate: mockAuthenticate,
+      });
+
+      const event = makeEvent(JSON.stringify({ expenseIds: ['EXP_A', 'NONEXISTENT'], reimbursedBy: 'Alice' }));
+      const result = await handler(event);
+
+      expect(result.statusCode).toBe(404);
+      const responseBody = JSON.parse(result.body as string) as ApiError;
+      expect(responseBody.code).toBe('NOT_FOUND');
+      expect(mockRepo.markReimbursedBulk).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('already reimbursed', () => {
+    it('returns 409 when any expense is already reimbursed', async () => {
+      mockAuthenticate.mockResolvedValue({ success: true, context: mockAuthContext });
+      mockRepo.getExpense.mockResolvedValueOnce(makeUnreimbursedExpense({ expenseId: 'EXP_A' }));
+      mockRepo.getExpense.mockResolvedValueOnce(makeReimbursedExpense({ expenseId: 'EXP_B' }));
+
+      const handler = createReimburseBulkHandler({
+        repo: mockRepo as unknown as ExpenseRepository,
+        authenticate: mockAuthenticate,
+      });
+
+      const event = makeEvent(JSON.stringify({ expenseIds: ['EXP_A', 'EXP_B'], reimbursedBy: 'Alice' }));
+      const result = await handler(event);
+
+      expect(result.statusCode).toBe(409);
+      const responseBody = JSON.parse(result.body as string) as ApiError;
+      expect(responseBody.code).toBe('ALREADY_REIMBURSED');
+      expect(responseBody.details).toEqual({ alreadyReimbursedIds: ['EXP_B'] });
+      expect(mockRepo.markReimbursedBulk).not.toHaveBeenCalled();
+    });
+
+    it('returns all already reimbursed IDs in details', async () => {
+      mockAuthenticate.mockResolvedValue({ success: true, context: mockAuthContext });
+      mockRepo.getExpense.mockResolvedValueOnce(makeReimbursedExpense({ expenseId: 'EXP_A' }));
+      mockRepo.getExpense.mockResolvedValueOnce(makeReimbursedExpense({ expenseId: 'EXP_B' }));
+
+      const handler = createReimburseBulkHandler({
+        repo: mockRepo as unknown as ExpenseRepository,
+        authenticate: mockAuthenticate,
+      });
+
+      const event = makeEvent(JSON.stringify({ expenseIds: ['EXP_A', 'EXP_B'], reimbursedBy: 'Alice' }));
+      const result = await handler(event);
+
+      expect(result.statusCode).toBe(409);
+      const responseBody = JSON.parse(result.body as string) as ApiError;
+      expect(responseBody.details).toEqual({ alreadyReimbursedIds: ['EXP_A', 'EXP_B'] });
+    });
+  });
+
+  describe('successful bulk reimbursement', () => {
+    it('returns 200 with expenses and count', async () => {
+      const expense1 = makeUnreimbursedExpense({ expenseId: 'EXP_A' });
+      const expense2 = makeUnreimbursedExpense({ expenseId: 'EXP_B' });
+      const reimbursed1 = makeReimbursedExpense({ expenseId: 'EXP_A' });
+      const reimbursed2 = makeReimbursedExpense({ expenseId: 'EXP_B' });
+
+      mockAuthenticate.mockResolvedValue({ success: true, context: mockAuthContext });
+      mockRepo.getExpense.mockResolvedValueOnce(expense1);
+      mockRepo.getExpense.mockResolvedValueOnce(expense2);
+      mockRepo.markReimbursedBulk.mockResolvedValue([reimbursed1, reimbursed2]);
+
+      const handler = createReimburseBulkHandler({
+        repo: mockRepo as unknown as ExpenseRepository,
+        authenticate: mockAuthenticate,
+      });
+
+      const event = makeEvent(JSON.stringify({ expenseIds: ['EXP_A', 'EXP_B'], reimbursedBy: 'Alice' }));
+      const result = await handler(event);
+
+      expect(result.statusCode).toBe(200);
+      const responseBody = JSON.parse(result.body as string) as BulkReimburseResponse;
+      expect(responseBody.count).toBe(2);
+      expect(responseBody.expenses).toHaveLength(2);
+      expect(responseBody.expenses[0].reimbursed).toBe(true);
+    });
+
+    it('passes correct arguments to repo.markReimbursedBulk', async () => {
+      const expense1 = makeUnreimbursedExpense({ expenseId: 'EXP_A' });
+      const expense2 = makeUnreimbursedExpense({ expenseId: 'EXP_B' });
+
+      mockAuthenticate.mockResolvedValue({ success: true, context: mockAuthContext });
+      mockRepo.getExpense.mockResolvedValueOnce(expense1);
+      mockRepo.getExpense.mockResolvedValueOnce(expense2);
+      mockRepo.markReimbursedBulk.mockResolvedValue([makeReimbursedExpense({ expenseId: 'EXP_A' }), makeReimbursedExpense({ expenseId: 'EXP_B' })]);
+
+      const handler = createReimburseBulkHandler({
+        repo: mockRepo as unknown as ExpenseRepository,
+        authenticate: mockAuthenticate,
+      });
+
+      const event = makeEvent(JSON.stringify({ expenseIds: ['EXP_A', 'EXP_B'], reimbursedBy: 'Alice' }));
+      await handler(event);
+
+      expect(mockRepo.markReimbursedBulk).toHaveBeenCalledTimes(1);
+      expect(mockRepo.markReimbursedBulk).toHaveBeenCalledWith(
+        'acct_01HXYZ',
+        [expense1, expense2],
+      );
+    });
+  });
+});

--- a/api/test/lib/dynamo.test.ts
+++ b/api/test/lib/dynamo.test.ts
@@ -6,6 +6,7 @@ import {
   QueryCommand,
   UpdateCommand,
   DeleteCommand,
+  TransactWriteCommand,
 } from '@aws-sdk/lib-dynamodb';
 import { ExpenseRepository } from '../../src/lib/dynamo.js';
 import type { AbleCategory, CreateExpenseInput, Expense } from '../../src/lib/types.js';
@@ -535,6 +536,94 @@ describe('ExpenseRepository', () => {
 
       const calls = ddbMock.commandCalls(UpdateCommand);
       expect(calls[0].args[0].input.ReturnValues).toBe('ALL_NEW');
+    });
+  });
+
+  describe('markReimbursedBulk', () => {
+    it('sends TransactWriteCommand with correct transact items for each expense', async () => {
+      const expenses = [
+        makeSampleExpense({ expenseId: 'EXP_A', date: '2025-03-10', paidBy: 'user-alice' }),
+        makeSampleExpense({ expenseId: 'EXP_B', date: '2025-03-12', paidBy: 'user-bob' }),
+      ];
+
+      ddbMock.on(TransactWriteCommand).resolves({});
+
+      await repo.markReimbursedBulk('acct-123', expenses);
+
+      const calls = ddbMock.commandCalls(TransactWriteCommand);
+      expect(calls).toHaveLength(1);
+
+      const transactItems = calls[0].args[0].input.TransactItems;
+      expect(transactItems).toHaveLength(2);
+    });
+
+    it('uses Update operation with condition expression to prevent double-reimbursement', async () => {
+      const expenses = [
+        makeSampleExpense({ expenseId: 'EXP_A', date: '2025-03-10', paidBy: 'user-alice' }),
+      ];
+
+      ddbMock.on(TransactWriteCommand).resolves({});
+
+      await repo.markReimbursedBulk('acct-123', expenses);
+
+      const calls = ddbMock.commandCalls(TransactWriteCommand);
+      const transactItems = calls[0].args[0].input.TransactItems!;
+      const updateItem = transactItems[0].Update!;
+
+      expect(updateItem.Key).toEqual({
+        PK: 'ACCOUNT#acct-123',
+        SK: 'EXP#2025-03-10#EXP_A',
+      });
+      expect(updateItem.ConditionExpression).toContain('reimbursed = :false');
+      expect(updateItem.UpdateExpression).toContain('reimbursed');
+      expect(updateItem.UpdateExpression).toContain('reimbursedAt');
+      expect(updateItem.UpdateExpression).toContain('updatedAt');
+      expect(updateItem.UpdateExpression).toContain('#gsi2sk');
+    });
+
+    it('sets correct GSI2SK values using each expense paidBy', async () => {
+      const expenses = [
+        makeSampleExpense({ expenseId: 'EXP_A', date: '2025-03-10', paidBy: 'user-alice' }),
+        makeSampleExpense({ expenseId: 'EXP_B', date: '2025-03-12', paidBy: 'user-bob' }),
+      ];
+
+      ddbMock.on(TransactWriteCommand).resolves({});
+
+      await repo.markReimbursedBulk('acct-123', expenses);
+
+      const calls = ddbMock.commandCalls(TransactWriteCommand);
+      const transactItems = calls[0].args[0].input.TransactItems!;
+
+      expect(transactItems[0].Update!.ExpressionAttributeValues![':gsi2sk']).toBe('PAID#user-alice#1#2025-03-10');
+      expect(transactItems[1].Update!.ExpressionAttributeValues![':gsi2sk']).toBe('PAID#user-bob#1#2025-03-12');
+    });
+
+    it('returns updated expenses with reimbursed=true and timestamps', async () => {
+      const expenses = [
+        makeSampleExpense({ expenseId: 'EXP_A', date: '2025-03-10', paidBy: 'user-alice' }),
+      ];
+
+      ddbMock.on(TransactWriteCommand).resolves({});
+
+      const result = await repo.markReimbursedBulk('acct-123', expenses);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].reimbursed).toBe(true);
+      expect(result[0].reimbursedAt).toBe('2025-03-15T10:00:00.000Z');
+      expect(result[0].updatedAt).toBe('2025-03-15T10:00:00.000Z');
+      expect(result[0].expenseId).toBe('EXP_A');
+    });
+
+    it('propagates TransactionCanceledException when condition check fails', async () => {
+      const expenses = [
+        makeSampleExpense({ expenseId: 'EXP_A', date: '2025-03-10', paidBy: 'user-alice' }),
+      ];
+
+      const error = new Error('Transaction cancelled');
+      error.name = 'TransactionCanceledException';
+      ddbMock.on(TransactWriteCommand).rejects(error);
+
+      await expect(repo.markReimbursedBulk('acct-123', expenses)).rejects.toThrow('Transaction cancelled');
     });
   });
 

--- a/infra/lib/api-stack.ts
+++ b/infra/lib/api-stack.ts
@@ -157,6 +157,14 @@ export class ApiStack extends cdk.Stack {
         dynamoAccess: 'readwrite',
       },
       {
+        id: 'ReimburseBulk',
+        method: HttpMethod.POST,
+        path: '/expenses/reimburse-bulk',
+        description: 'Bulk mark expenses as reimbursed',
+        entry: path.join(HANDLERS_DIR, 'expenses/reimburse-bulk.handler.ts'),
+        dynamoAccess: 'readwrite',
+      },
+      {
         id: 'DashboardReimbursements',
         method: HttpMethod.GET,
         path: '/dashboard/reimbursements',

--- a/infra/test/api-stack.test.ts
+++ b/infra/test/api-stack.test.ts
@@ -116,7 +116,7 @@ describe('ApiStack', () => {
     it('attaches authorization to all routes', () => {
       const routes = template.findResources('AWS::ApiGatewayV2::Route');
       const routeKeys = Object.keys(routes);
-      expect(routeKeys.length).toBe(7);
+      expect(routeKeys.length).toBe(8);
 
       for (const key of routeKeys) {
         expect(routes[key].Properties.AuthorizationType).toBe('JWT');
@@ -126,8 +126,8 @@ describe('ApiStack', () => {
   });
 
   describe('Lambda Functions', () => {
-    it('creates Lambda functions for all 7 endpoints', () => {
-      template.resourceCountIs('AWS::Lambda::Function', 7);
+    it('creates Lambda functions for all 8 endpoints', () => {
+      template.resourceCountIs('AWS::Lambda::Function', 8);
     });
 
     it('does not use placeholder inline code for any Lambda function (#74)', () => {
@@ -146,7 +146,7 @@ describe('ApiStack', () => {
     it('uses Node.js 20 runtime for all Lambda functions', () => {
       const functions = template.findResources('AWS::Lambda::Function');
       const functionKeys = Object.keys(functions);
-      expect(functionKeys.length).toBe(7);
+      expect(functionKeys.length).toBe(8);
 
       for (const key of functionKeys) {
         expect(functions[key].Properties.Runtime).toBe('nodejs20.x');
@@ -199,8 +199,8 @@ describe('ApiStack', () => {
   });
 
   describe('API Routes', () => {
-    it('creates routes for all 7 endpoints', () => {
-      template.resourceCountIs('AWS::ApiGatewayV2::Route', 7);
+    it('creates routes for all 8 endpoints', () => {
+      template.resourceCountIs('AWS::ApiGatewayV2::Route', 8);
     });
 
     it('creates POST /expenses route', () => {
@@ -230,6 +230,12 @@ describe('ApiStack', () => {
     it('creates PUT /expenses/{id}/reimburse route', () => {
       template.hasResourceProperties('AWS::ApiGatewayV2::Route', {
         RouteKey: 'PUT /expenses/{id}/reimburse',
+      });
+    });
+
+    it('creates POST /expenses/reimburse-bulk route', () => {
+      template.hasResourceProperties('AWS::ApiGatewayV2::Route', {
+        RouteKey: 'POST /expenses/reimburse-bulk',
       });
     });
 
@@ -325,6 +331,12 @@ describe('ApiStack', () => {
 
     it('ReimburseExpense gets DynamoDB read/write access', () => {
       const stmts = getPolicyStatementsForFunction(template, 'Mark an expense as reimbursed');
+      expect(statementsHaveDynamoRead(stmts)).toBe(true);
+      expect(statementsHaveDynamoWrite(stmts)).toBe(true);
+    });
+
+    it('ReimburseBulk gets DynamoDB read/write access', () => {
+      const stmts = getPolicyStatementsForFunction(template, 'Bulk mark expenses as reimbursed');
       expect(statementsHaveDynamoRead(stmts)).toBe(true);
       expect(statementsHaveDynamoWrite(stmts)).toBe(true);
     });


### PR DESCRIPTION
## Summary

- Add `POST /expenses/reimburse-bulk` endpoint for atomically marking multiple expenses as reimbursed
- Add `BulkReimburseRequest` / `BulkReimburseResponse` types to `api/src/lib/types.ts`
- Add `markReimbursedBulk` repository method using DynamoDB `TransactWriteCommand` for atomic all-or-nothing updates with condition expressions to prevent double-reimbursement
- Add handler with full validation: auth (401), body parsing, expenseIds array (1-100), reimbursedBy string, not-found (404), already-reimbursed (409 with detail IDs)
- Add CDK route with `readwrite` DynamoDB access and IAM tests

## Test plan

- [x] 5 repository tests for `markReimbursedBulk` (TransactWriteCommand, condition expressions, GSI2SK, return values, error propagation)
- [x] 16 handler tests covering auth, validation (9 cases), not-found, already-reimbursed, success (2 cases)
- [x] 3 CDK assertion tests (route exists, route count, IAM permissions)
- [x] TypeScript strict compilation passes
- [x] All 252 API tests pass
- [x] All 102 infra tests pass

Closes #109 (backend half)

🤖 Generated with [Claude Code](https://claude.com/claude-code)