### PR TITLE
feat: CI antipattern lint hook + ephemeral secrets check

### DIFF
--- a/.claude/hooks/check-ci-antipatterns.sh
+++ b/.claude/hooks/check-ci-antipatterns.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# PreToolUse hook: detect || true, || exit 0, ; true on test commands in workflow files
+#
+# Receives JSON on stdin with tool_name and tool_input.
+# For Write: checks tool_input.content
+# For Edit: checks tool_input.new_string
+#
+# Exit 0 = allow, exit 2 = block (stderr shown to user)
+
+set -euo pipefail
+
+INPUT=$(cat)
+
+TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty')
+
+# Only check Write and Edit tools
+case "$TOOL_NAME" in
+  Write|Edit) ;;
+  *) exit 0 ;;
+esac
+
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
+
+# Only check workflow YAML files
+case "$FILE_PATH" in
+  *.github/workflows/*.yml|*.github/workflows/*.yaml) ;;
+  .github/workflows/*.yml|.github/workflows/*.yaml) ;;
+  *) exit 0 ;;
+esac
+
+# Extract content to scan
+if [ "$TOOL_NAME" = "Write" ]; then
+  CONTENT=$(echo "$INPUT" | jq -r '.tool_input.content // empty')
+elif [ "$TOOL_NAME" = "Edit" ]; then
+  CONTENT=$(echo "$INPUT" | jq -r '.tool_input.new_string // empty')
+fi
+
+if [ -z "$CONTENT" ]; then
+  exit 0
+fi
+
+VIOLATIONS_FOUND=0
+VIOLATION_DETAILS=""
+
+# Test-related command patterns
+TEST_PATTERN='(pnpm\s+(test|.*test:e2e)|npx\s+(vitest|jest|playwright)|playwright\s+test|vitest|jest)'
+
+# Anti-patterns that suppress test failures
+ANTIPATTERN='\|\|\s*(true|exit\s+0)|;\s*true\s*$'
+
+line_num=0
+while IFS= read -r line; do
+  line_num=$((line_num + 1))
+
+  [ -z "$line" ] && continue
+
+  # Skip comment lines
+  if echo "$line" | grep -qE '^\s*#'; then
+    continue
+  fi
+
+  # Check if this line has a test command AND a failure-suppressing antipattern
+  if echo "$line" | grep -qiP "$TEST_PATTERN" && echo "$line" | grep -qP "$ANTIPATTERN"; then
+    VIOLATIONS_FOUND=$((VIOLATIONS_FOUND + 1))
+    VIOLATION_DETAILS="${VIOLATION_DETAILS}\n  Line ${line_num}: ${line}"
+  fi
+done <<< "$CONTENT"
+
+if [ "$VIOLATIONS_FOUND" -gt 0 ]; then
+  echo "BLOCKED: Found $VIOLATIONS_FOUND test command(s) with failure-suppressing antipattern in ${FILE_PATH}:" >&2
+  echo -e "$VIOLATION_DETAILS" >&2
+  echo "" >&2
+  echo "Why: Using '|| true', '|| exit 0', or '; true' on test commands silently swallows" >&2
+  echo "test failures, making the entire CI pipeline decorative (Sprint 7 retro item #2)." >&2
+  echo "" >&2
+  echo "Instead, use 'continue-on-error: true' at the step level if you need the workflow" >&2
+  echo "to continue after test failures while still reporting the failure status." >&2
+  exit 2
+fi
+
+exit 0

--- a/.claude/hooks/test-check-ci-antipatterns.sh
+++ b/.claude/hooks/test-check-ci-antipatterns.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+# Test suite for check-ci-antipatterns.sh
+# Simulates PreToolUse JSON input and verifies the hook catches
+# || true / || exit 0 / ; true on test commands in workflow files.
+#
+# Exit 0 = allow, exit 2 = block
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HOOK_SCRIPT="$SCRIPT_DIR/check-ci-antipatterns.sh"
+
+PASS=0
+FAIL=0
+TESTS_RUN=0
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+# Helper: run the hook with simulated PreToolUse JSON input
+# Usage: run_test "test name" "tool_name" "file_path" "content" expected_exit_code
+run_test() {
+  local test_name="$1"
+  local tool_name="$2"
+  local file_path="$3"
+  local content="$4"
+  local expected_exit="$5"
+
+  TESTS_RUN=$((TESTS_RUN + 1))
+
+  # Build JSON input matching PreToolUse schema
+  local json_input
+  if [ "$tool_name" = "Write" ]; then
+    json_input=$(jq -n \
+      --arg tn "$tool_name" \
+      --arg fp "$file_path" \
+      --arg c "$content" \
+      '{tool_name: $tn, tool_input: {file_path: $fp, content: $c}}')
+  else
+    json_input=$(jq -n \
+      --arg tn "$tool_name" \
+      --arg fp "$file_path" \
+      --arg c "$content" \
+      '{tool_name: $tn, tool_input: {file_path: $fp, new_string: $c}}')
+  fi
+
+  local actual_exit=0
+  echo "$json_input" | bash "$HOOK_SCRIPT" > /dev/null 2>&1 || actual_exit=$?
+
+  if [ "$actual_exit" -eq "$expected_exit" ]; then
+    echo -e "  ${GREEN}PASS${NC}: $test_name"
+    PASS=$((PASS + 1))
+  else
+    echo -e "  ${RED}FAIL${NC}: $test_name (expected exit=$expected_exit, got exit=$actual_exit)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+echo ""
+echo "========================================"
+echo " Testing check-ci-antipatterns.sh"
+echo "========================================"
+echo ""
+
+# ---- Tests that SHOULD be blocked (exit 2) ----
+echo -e "${YELLOW}--- Patterns that should be BLOCKED ---${NC}"
+
+run_test "|| true on test command" \
+  "Write" \
+  ".github/workflows/test.yml" \
+  "      - name: Test
+        run: pnpm test || true" \
+  2
+
+run_test "|| true on vitest command" \
+  "Write" \
+  ".github/workflows/ci.yml" \
+  "      - name: Run tests
+        run: npx vitest || true" \
+  2
+
+run_test "|| true on playwright command" \
+  "Write" \
+  ".github/workflows/e2e.yml" \
+  "      - name: E2E
+        run: pnpm exec playwright test || true" \
+  2
+
+run_test "|| exit 0 on test command" \
+  "Write" \
+  ".github/workflows/test.yml" \
+  "      - name: Test
+        run: pnpm test || exit 0" \
+  2
+
+run_test "; true after test command" \
+  "Write" \
+  ".github/workflows/test.yml" \
+  "      - name: Test
+        run: pnpm test ; true" \
+  2
+
+run_test "|| true on test:e2e command" \
+  "Edit" \
+  ".github/workflows/e2e.yml" \
+  "        run: pnpm --filter web test:e2e || true" \
+  2
+
+run_test "|| true on jest command" \
+  "Write" \
+  ".github/workflows/test.yml" \
+  "        run: npx jest --coverage || true" \
+  2
+
+# ---- Tests that SHOULD be allowed (exit 0) ----
+echo ""
+echo -e "${YELLOW}--- Patterns that should be ALLOWED ---${NC}"
+
+run_test "Clean test command (no || true)" \
+  "Write" \
+  ".github/workflows/test.yml" \
+  "      - name: Test
+        run: pnpm test" \
+  0
+
+run_test "Non-workflow file with || true" \
+  "Write" \
+  "scripts/run-tests.sh" \
+  "pnpm test || true" \
+  0
+
+run_test "|| true on non-test command in workflow" \
+  "Write" \
+  ".github/workflows/deploy.yml" \
+  "        run: aws cloudformation describe-stacks || true" \
+  0
+
+run_test "continue-on-error instead of || true" \
+  "Write" \
+  ".github/workflows/test.yml" \
+  "      - name: Test
+        run: pnpm test
+        continue-on-error: true" \
+  0
+
+run_test "Non-Write/Edit tool" \
+  "Bash" \
+  ".github/workflows/test.yml" \
+  "pnpm test || true" \
+  0
+
+run_test "Comment mentioning || true" \
+  "Write" \
+  ".github/workflows/test.yml" \
+  "      # Never use || true on test commands" \
+  0
+
+run_test "Clean playwright command" \
+  "Write" \
+  ".github/workflows/e2e.yml" \
+  "        run: pnpm --filter web test:e2e
+        env:
+          CI: 'true'" \
+  0
+
+# ---- Summary ----
+echo ""
+echo "========================================"
+echo " Test Summary"
+echo "========================================"
+echo ""
+echo -e "  Total:  $TESTS_RUN"
+echo -e "  ${GREEN}Passed: $PASS${NC}"
+if [ "$FAIL" -gt 0 ]; then
+  echo -e "  ${RED}Failed: $FAIL${NC}"
+else
+  echo -e "  Failed: $FAIL"
+fi
+echo ""
+
+if [ "$FAIL" -gt 0 ]; then
+  echo -e "${RED}SOME TESTS FAILED${NC}"
+  exit 1
+else
+  echo -e "${GREEN}ALL TESTS PASSED${NC}"
+  exit 0
+fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,6 +7,10 @@
           {
             "type": "command",
             "command": "bash .claude/hooks/check-secrets-pretooluse.sh"
+          },
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/check-ci-antipatterns.sh"
           }
         ]
       }
@@ -17,13 +21,13 @@
         "hooks": [
           {
             "type": "agent",
-            "prompt": "Review the changes this agent made for security issues. CRITICAL (always block): 1) Any API endpoint, route, or page accessible without authentication — every API handler MUST validate auth context and every frontend route with data MUST require login. 2) Hardcoded secrets, credentials, or API keys. HIGH (block): IDOR/cross-account data access, overly permissive IAM policies, missing authorization checks, PII exposure, XSS, injection, OWASP top 10. Specifically verify: all Lambda handlers check event.requestContext.authorizer, all frontend routes with data are behind auth guards, no API returns user data without a valid JWT. Only report CRITICAL or HIGH findings that should block. If no blocking findings, respond with APPROVED. Be concise — max 10 lines.",
+            "prompt": "Review the changes this agent made for security issues. CRITICAL (always block): 1) Any API endpoint, route, or page accessible without authentication \u2014 every API handler MUST validate auth context and every frontend route with data MUST require login. 2) Hardcoded secrets, credentials, or API keys. HIGH (block): IDOR/cross-account data access, overly permissive IAM policies, missing authorization checks, PII exposure, XSS, injection, OWASP top 10. Specifically verify: all Lambda handlers check event.requestContext.authorizer, all frontend routes with data are behind auth guards, no API returns user data without a valid JWT. Only report CRITICAL or HIGH findings that should block. If no blocking findings, respond with APPROVED. Be concise \u2014 max 10 lines.",
             "model": "claude-sonnet-4-6",
             "statusMessage": "Security review..."
           },
           {
             "type": "agent",
-            "prompt": "Review the changes this agent made for QA/engineering quality. Check: 1) Tests exist for new code — test files should be written BEFORE or alongside implementation (TDD). Flag if new handlers, components, or utilities lack corresponding test files. 2) No skipped or disabled tests (.skip, .todo without justification). 3) No TypeScript `any` types — must use `unknown` with type guards. 4) Test assertions are meaningful — not just `toBeTruthy()` or `toBeDefined()` on everything; tests should verify specific values and behavior. 5) No `@ts-ignore` or `@ts-expect-error` without explanatory comments. 6) Money values use integers (cents), not floats. Rate findings: CRITICAL (no tests for new code, `any` types), HIGH (skipped tests, weak assertions, @ts-ignore without comment). Only report CRITICAL or HIGH findings that should block. If no blocking findings, respond with APPROVED. Be concise — max 10 lines.",
+            "prompt": "Review the changes this agent made for QA/engineering quality. Check: 1) Tests exist for new code \u2014 test files should be written BEFORE or alongside implementation (TDD). Flag if new handlers, components, or utilities lack corresponding test files. 2) No skipped or disabled tests (.skip, .todo without justification). 3) No TypeScript `any` types \u2014 must use `unknown` with type guards. 4) Test assertions are meaningful \u2014 not just `toBeTruthy()` or `toBeDefined()` on everything; tests should verify specific values and behavior. 5) No `@ts-ignore` or `@ts-expect-error` without explanatory comments. 6) Money values use integers (cents), not floats. Rate findings: CRITICAL (no tests for new code, `any` types), HIGH (skipped tests, weak assertions, @ts-ignore without comment). Only report CRITICAL or HIGH findings that should block. If no blocking findings, respond with APPROVED. Be concise \u2014 max 10 lines.",
             "model": "claude-sonnet-4-6",
             "statusMessage": "QA review..."
           }

--- a/.github/workflows/ephemeral-e2e.yml
+++ b/.github/workflows/ephemeral-e2e.yml
@@ -30,6 +30,36 @@ jobs:
       table-name: ${{ steps.outputs.outputs.table-name }}
 
     steps:
+      - name: Check required secrets
+        run: |
+          MISSING=""
+          if [ -z "${{ secrets.E2E_TEST_PASSWORD }}" ]; then
+            MISSING="${MISSING}\n  - E2E_TEST_PASSWORD"
+          fi
+          if [ -z "${{ secrets.AWS_DEPLOY_ROLE_ARN }}" ]; then
+            MISSING="${MISSING}\n  - AWS_DEPLOY_ROLE_ARN"
+          fi
+          if [ -n "$MISSING" ]; then
+            echo "::error::Missing required secrets for ephemeral environment"
+            echo ""
+            echo "================================================"
+            echo " MISSING REQUIRED SECRETS"
+            echo "================================================"
+            echo ""
+            echo -e "The following secrets are not set:${MISSING}"
+            echo ""
+            echo "To fix this, go to:"
+            echo "  GitHub repo > Settings > Environments > dev > Environment secrets"
+            echo ""
+            echo "Required secrets:"
+            echo "  - E2E_TEST_PASSWORD: Password for the E2E test user (Cognito)"
+            echo "  - AWS_DEPLOY_ROLE_ARN: IAM role ARN for AWS deployments (OIDC)"
+            echo ""
+            echo "See docs/SETUP.md for full configuration details."
+            exit 1
+          fi
+          echo "All required secrets are configured."
+
       - name: Checkout
         uses: actions/checkout@v4
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,6 +121,13 @@ These are non-negotiable. Every agent must follow them. They are the guardrails 
 - `matcher` is a regex matched against tool names (e.g., `"Write|Edit"`, `"Bash"`)
 - Each hook object requires `type` (`"command"`, `"prompt"`, or `"agent"`) plus the corresponding field
 
+#### Active Hooks
+
+| Hook Script | Trigger | Purpose |
+|-------------|---------|---------|
+| `check-secrets-pretooluse.sh` | `Write\|Edit` | Blocks commits containing hardcoded secrets, API keys, or credentials |
+| `check-ci-antipatterns.sh` | `Write\|Edit` | Blocks `\|\| true`, `\|\| exit 0`, `; true` on test commands in workflow YAML files. Use `continue-on-error: true` instead. |
+
 ### Git Conventions
 
 - **`main` is protected.** Never push directly to main. All changes must go through a feature branch and PR.

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -91,6 +91,41 @@ After deployment completes, note the stack outputs:
 4. Enter the user's email and set a temporary password
 5. The user will be prompted to set a new password on first login
 
+## GitHub Secrets for CI/CD
+
+GitHub Actions workflows require secrets configured in your repository. Go to **Settings > Environments > dev > Environment secrets** to set them.
+
+### Required for All Deployments
+
+| Secret | Description |
+|--------|-------------|
+| `AWS_DEPLOY_ROLE_ARN` | IAM role ARN for OIDC-based AWS authentication (e.g., `arn:aws:iam::123456789012:role/GitHubActionsDeployRole`) |
+
+### Required for E2E / Ephemeral Environments
+
+| Secret | Description |
+|--------|-------------|
+| `E2E_TEST_PASSWORD` | Password for the E2E test user created in Cognito during ephemeral deploys |
+
+### Required for Smoke Tests
+
+| Secret | Description |
+|--------|-------------|
+| `SMOKE_TEST_EMAIL` | Email of an existing Cognito user for smoke tests |
+| `SMOKE_TEST_PASSWORD` | Password for the smoke test user |
+
+### Required for Security Review
+
+| Secret | Description |
+|--------|-------------|
+| `ANTHROPIC_API_KEY` | API key for Claude-powered automated security review on PRs |
+
+### Repository Variables (Settings > Environments > dev > Variables)
+
+| Variable | Description |
+|----------|-------------|
+| `AWS_REGION` | AWS region for deployments (e.g., `us-east-1`) |
+
 ## Teardown
 
 To remove all deployed resources:


### PR DESCRIPTION
## Summary

- **#133**: Add `check-ci-antipatterns.sh` PreToolUse hook that blocks `|| true`, `|| exit 0`, and `; true` on test/vitest/playwright/jest commands in workflow YAML files (Sprint 7 retro item #2). Includes 14-test suite and suggests `continue-on-error: true` as the safe alternative.
- **#135**: Add early secrets validation step to `ephemeral-e2e.yml` that fails fast with actionable error message if `E2E_TEST_PASSWORD` or `AWS_DEPLOY_ROLE_ARN` are missing, directing users to Settings > Environments > dev > Secrets.
- Document all required GitHub secrets in `docs/SETUP.md` and active hooks in `CLAUDE.md`.

Closes #133, closes #135

## Test plan

- [x] 14 hook tests pass (7 blocked patterns, 7 allowed patterns)
- [x] All existing workflows pass the hook check
- [x] Hooks format validated by `scripts/validate-hooks.mjs`
- [x] YAML syntax validated for modified workflow
- [x] All unit tests pass (pre-push hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)