### PR TITLE
docs: update worktree agent prompt with rebase and verify steps

### DIFF
--- a/.claude/skills/plan-next-sprint/SKILL.md
+++ b/.claude/skills/plan-next-sprint/SKILL.md
@@ -237,8 +237,12 @@ Include this block verbatim in every implementing agent's prompt:
 copy of the repository just for you. Your working directory is already set to your
 worktree root. No other agent shares this directory.
 - Run `pwd` first to confirm your working directory
-- Create your feature branch here: `git checkout -b <branch-name>`
+- Run `git fetch origin main && git rebase origin/main` to get latest code
+- Run `pnpm install` to pick up any new dependencies
+- THEN create your feature branch: `git checkout -b <branch-name>`
 - Do ALL work in this directory — do NOT cd to the main repository or other worktrees
+- After committing, run `git log --oneline -3` to verify your commit is on the branch
+- Before pushing, run `git fetch origin main && git rebase origin/main` again
 - Your worktree is independent — commit, push, and create PRs from here
 ```
 


### PR DESCRIPTION
## Summary

- Updates the worktree instruction block in `.claude/skills/plan-next-sprint/SKILL.md` to prevent stale dependency and branch confusion issues observed in Sprint 8
- Adds `git fetch origin main && git rebase origin/main` before creating the feature branch
- Adds `pnpm install` to pick up new dependencies
- Adds `git log --oneline -3` verification after committing
- Adds second rebase before pushing

Closes #151

## Test plan

- [x] Verified the updated instruction block matches the format in MEMORY.md
- [x] All existing tests pass (pre-push hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)