### PR TITLE
feat: implement /dashboard/reimbursements endpoint (#144)

### DIFF
--- a/api/src/handlers/dashboard/reimbursements.handler.ts
+++ b/api/src/handlers/dashboard/reimbursements.handler.ts
@@ -1,0 +1,18 @@
+/**
+ * Lambda entry point for GET /dashboard/reimbursements.
+ * Wires up real AWS dependencies and exports the handler.
+ */
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
+import { ExpenseRepository } from '../../lib/dynamo.js';
+import { extractAuthContext } from '../../middleware/auth.js';
+import { createDashboardReimbursementsHandler } from './reimbursements.js';
+
+const ddbClient = new DynamoDBClient({});
+const docClient = DynamoDBDocumentClient.from(ddbClient);
+const repo = new ExpenseRepository(docClient, process.env['TABLE_NAME']!);
+
+export const handler = createDashboardReimbursementsHandler({
+  repo,
+  authenticate: async (event) => extractAuthContext(event),
+});

--- a/api/src/handlers/dashboard/reimbursements.ts
+++ b/api/src/handlers/dashboard/reimbursements.ts
@@ -1,0 +1,81 @@
+import type { APIGatewayProxyEventV2, APIGatewayProxyResultV2 } from 'aws-lambda';
+import type { ExpenseRepository } from '../../lib/dynamo.js';
+import type { AuthResult } from '../../middleware/auth.js';
+import type { ReimbursementSummary } from '../../lib/types.js';
+import { createLogger, extractRequestId } from '../../lib/logger.js';
+
+/**
+ * Dependencies injected into the dashboard reimbursements handler.
+ * Uses a factory pattern so tests can inject mocks.
+ */
+export interface DashboardReimbursementsHandlerDeps {
+  repo: ExpenseRepository;
+  authenticate: (event: APIGatewayProxyEventV2) => Promise<AuthResult>;
+}
+
+/**
+ * Factory function that creates the Lambda handler for GET /dashboard/reimbursements.
+ *
+ * The handler:
+ * 1. Authenticates the request using the injected auth middleware
+ * 2. Fetches all unreimbursed expenses for the account
+ * 3. Aggregates by paidBy: sums amount and counts expenses per payer
+ * 4. Returns { summaries: ReimbursementSummary[] }
+ */
+export function createDashboardReimbursementsHandler(deps: DashboardReimbursementsHandlerDeps) {
+  const log = createLogger('DashboardReimbursements');
+
+  return async (event: APIGatewayProxyEventV2): Promise<APIGatewayProxyResultV2> => {
+    const requestId = extractRequestId(event as unknown as Record<string, unknown>);
+    log.info('Request started', requestId);
+
+    // 1. Authenticate
+    const authResult = await deps.authenticate(event);
+    if (!authResult.success) {
+      log.warn('Authentication failed', requestId);
+      return authResult.response;
+    }
+    const { context } = authResult;
+
+    try {
+      // 2. Fetch unreimbursed expenses
+      const expenses = await deps.repo.listExpenses(context.accountId, { reimbursed: false });
+
+      // 3. Aggregate by paidBy
+      const byPayer = new Map<string, { totalOwed: number; expenseCount: number }>();
+
+      for (const expense of expenses) {
+        const existing = byPayer.get(expense.paidBy);
+        if (existing) {
+          existing.totalOwed += expense.amount;
+          existing.expenseCount += 1;
+        } else {
+          byPayer.set(expense.paidBy, { totalOwed: expense.amount, expenseCount: 1 });
+        }
+      }
+
+      // 4. Build summaries
+      const summaries: ReimbursementSummary[] = [];
+      for (const [paidBy, agg] of byPayer) {
+        summaries.push({
+          userId: paidBy,
+          displayName: paidBy,
+          totalOwed: agg.totalOwed,
+          expenseCount: agg.expenseCount,
+        });
+      }
+
+      log.info('Request completed', requestId, { statusCode: 200, summaryCount: summaries.length });
+      return {
+        statusCode: 200,
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ summaries }),
+      };
+    } catch (err: unknown) {
+      const errorName = err instanceof Error ? err.name : 'UnknownError';
+      const errorMessage = err instanceof Error ? err.message : String(err);
+      log.error('Failed to fetch reimbursement summaries', requestId, { errorName, errorMessage });
+      throw err;
+    }
+  };
+}

--- a/api/test/handlers/dashboard/reimbursements.test.ts
+++ b/api/test/handlers/dashboard/reimbursements.test.ts
@@ -1,0 +1,278 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { APIGatewayProxyEventV2 } from 'aws-lambda';
+import type { AuthResult, AuthContext } from '../../../src/middleware/auth.js';
+import type { ExpenseRepository } from '../../../src/lib/dynamo.js';
+import type { Expense, ReimbursementSummary, ApiError } from '../../../src/lib/types.js';
+import { createDashboardReimbursementsHandler } from '../../../src/handlers/dashboard/reimbursements.js';
+
+/**
+ * Standard authenticated user context used across tests.
+ */
+const mockAuthContext: AuthContext = {
+  userId: 'user-alice-sub',
+  accountId: 'acct_01HXYZ',
+  email: 'alice@example.com',
+  displayName: 'Alice Smith',
+  role: 'owner',
+};
+
+/**
+ * Build a minimal APIGatewayProxyEventV2 for GET /dashboard/reimbursements.
+ */
+function makeEvent(): APIGatewayProxyEventV2 {
+  return {
+    version: '2.0',
+    routeKey: 'GET /dashboard/reimbursements',
+    rawPath: '/dashboard/reimbursements',
+    rawQueryString: '',
+    headers: {
+      'content-type': 'application/json',
+      authorization: 'Bearer valid-token',
+    },
+    requestContext: {
+      accountId: '123456789012',
+      apiId: 'api-id',
+      domainName: 'test.execute-api.us-east-1.amazonaws.com',
+      domainPrefix: 'test',
+      http: {
+        method: 'GET',
+        path: '/dashboard/reimbursements',
+        protocol: 'HTTP/1.1',
+        sourceIp: '127.0.0.1',
+        userAgent: 'test-agent',
+      },
+      requestId: 'request-id',
+      routeKey: 'GET /dashboard/reimbursements',
+      stage: '$default',
+      time: '15/Mar/2025:00:00:00 +0000',
+      timeEpoch: 1742169600000,
+    },
+    isBase64Encoded: false,
+  };
+}
+
+/**
+ * Build a mock Expense object.
+ */
+function makeMockExpense(overrides: Partial<Expense> = {}): Expense {
+  return {
+    expenseId: 'EXP_ULID_01',
+    accountId: 'acct_01HXYZ',
+    date: '2025-03-15',
+    vendor: 'Walgreens',
+    description: 'Medication co-pay',
+    amount: 2499,
+    category: 'Health, prevention & wellness',
+    categoryConfidence: 'ai_confirmed',
+    categoryNotes: 'Over-the-counter medication',
+    receiptKey: 'receipts/acct_01HXYZ/receipt-001.jpg',
+    submittedBy: 'user-alice-sub',
+    paidBy: 'Alice Smith',
+    reimbursed: false,
+    reimbursedAt: null,
+    createdAt: '2025-03-15T10:00:00.000Z',
+    updatedAt: '2025-03-15T10:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('createDashboardReimbursementsHandler', () => {
+  let mockRepo: {
+    listExpenses: ReturnType<typeof vi.fn>;
+  };
+  let mockAuthenticate: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    mockRepo = {
+      listExpenses: vi.fn(),
+    };
+    mockAuthenticate = vi.fn<(event: APIGatewayProxyEventV2) => Promise<AuthResult>>();
+  });
+
+  describe('authentication', () => {
+    it('returns 401 when auth middleware fails', async () => {
+      mockAuthenticate.mockResolvedValue({
+        success: false,
+        response: {
+          statusCode: 401,
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ error: 'Missing Authorization header', code: 'UNAUTHORIZED' }),
+        },
+      });
+
+      const handler = createDashboardReimbursementsHandler({
+        repo: mockRepo as unknown as ExpenseRepository,
+        authenticate: mockAuthenticate,
+      });
+
+      const event = makeEvent();
+      delete event.headers['authorization'];
+
+      const result = await handler(event);
+
+      expect(result.statusCode).toBe(401);
+      const responseBody = JSON.parse(result.body as string) as ApiError;
+      expect(responseBody.code).toBe('UNAUTHORIZED');
+      expect(mockRepo.listExpenses).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('happy path — empty summaries', () => {
+    it('returns 200 with empty summaries when no unreimbursed expenses exist', async () => {
+      mockAuthenticate.mockResolvedValue({ success: true, context: mockAuthContext });
+      mockRepo.listExpenses.mockResolvedValue([]);
+
+      const handler = createDashboardReimbursementsHandler({
+        repo: mockRepo as unknown as ExpenseRepository,
+        authenticate: mockAuthenticate,
+      });
+
+      const result = await handler(makeEvent());
+
+      expect(result.statusCode).toBe(200);
+      const body = JSON.parse(result.body as string) as { summaries: ReimbursementSummary[] };
+      expect(body.summaries).toEqual([]);
+    });
+
+    it('calls repo.listExpenses with reimbursed: false filter', async () => {
+      mockAuthenticate.mockResolvedValue({ success: true, context: mockAuthContext });
+      mockRepo.listExpenses.mockResolvedValue([]);
+
+      const handler = createDashboardReimbursementsHandler({
+        repo: mockRepo as unknown as ExpenseRepository,
+        authenticate: mockAuthenticate,
+      });
+
+      await handler(makeEvent());
+
+      expect(mockRepo.listExpenses).toHaveBeenCalledWith('acct_01HXYZ', { reimbursed: false });
+    });
+  });
+
+  describe('happy path — single payer', () => {
+    it('returns one summary for a single payer with correct totals', async () => {
+      const expenses = [
+        makeMockExpense({ expenseId: 'EXP_01', amount: 2499, paidBy: 'Bob Jones' }),
+        makeMockExpense({ expenseId: 'EXP_02', amount: 1500, paidBy: 'Bob Jones' }),
+      ];
+
+      mockAuthenticate.mockResolvedValue({ success: true, context: mockAuthContext });
+      mockRepo.listExpenses.mockResolvedValue(expenses);
+
+      const handler = createDashboardReimbursementsHandler({
+        repo: mockRepo as unknown as ExpenseRepository,
+        authenticate: mockAuthenticate,
+      });
+
+      const result = await handler(makeEvent());
+
+      expect(result.statusCode).toBe(200);
+      const body = JSON.parse(result.body as string) as { summaries: ReimbursementSummary[] };
+      expect(body.summaries).toHaveLength(1);
+      expect(body.summaries[0]).toEqual({
+        userId: 'Bob Jones',
+        displayName: 'Bob Jones',
+        totalOwed: 3999,
+        expenseCount: 2,
+      });
+    });
+  });
+
+  describe('happy path — multiple payers', () => {
+    it('returns separate summaries for each payer', async () => {
+      const expenses = [
+        makeMockExpense({ expenseId: 'EXP_01', amount: 2499, paidBy: 'Bob Jones' }),
+        makeMockExpense({ expenseId: 'EXP_02', amount: 1500, paidBy: 'Carol White' }),
+        makeMockExpense({ expenseId: 'EXP_03', amount: 3000, paidBy: 'Bob Jones' }),
+      ];
+
+      mockAuthenticate.mockResolvedValue({ success: true, context: mockAuthContext });
+      mockRepo.listExpenses.mockResolvedValue(expenses);
+
+      const handler = createDashboardReimbursementsHandler({
+        repo: mockRepo as unknown as ExpenseRepository,
+        authenticate: mockAuthenticate,
+      });
+
+      const result = await handler(makeEvent());
+
+      expect(result.statusCode).toBe(200);
+      const body = JSON.parse(result.body as string) as { summaries: ReimbursementSummary[] };
+      expect(body.summaries).toHaveLength(2);
+
+      const bob = body.summaries.find((s) => s.displayName === 'Bob Jones');
+      const carol = body.summaries.find((s) => s.displayName === 'Carol White');
+
+      expect(bob).toEqual({
+        userId: 'Bob Jones',
+        displayName: 'Bob Jones',
+        totalOwed: 5499,
+        expenseCount: 2,
+      });
+      expect(carol).toEqual({
+        userId: 'Carol White',
+        displayName: 'Carol White',
+        totalOwed: 1500,
+        expenseCount: 1,
+      });
+    });
+  });
+
+  describe('aggregation correctness', () => {
+    it('sums amounts correctly across many expenses', async () => {
+      const expenses = [
+        makeMockExpense({ expenseId: 'EXP_01', amount: 100, paidBy: 'Alice' }),
+        makeMockExpense({ expenseId: 'EXP_02', amount: 200, paidBy: 'Alice' }),
+        makeMockExpense({ expenseId: 'EXP_03', amount: 300, paidBy: 'Alice' }),
+        makeMockExpense({ expenseId: 'EXP_04', amount: 400, paidBy: 'Alice' }),
+      ];
+
+      mockAuthenticate.mockResolvedValue({ success: true, context: mockAuthContext });
+      mockRepo.listExpenses.mockResolvedValue(expenses);
+
+      const handler = createDashboardReimbursementsHandler({
+        repo: mockRepo as unknown as ExpenseRepository,
+        authenticate: mockAuthenticate,
+      });
+
+      const result = await handler(makeEvent());
+      const body = JSON.parse(result.body as string) as { summaries: ReimbursementSummary[] };
+
+      expect(body.summaries).toHaveLength(1);
+      expect(body.summaries[0].totalOwed).toBe(1000);
+      expect(body.summaries[0].expenseCount).toBe(4);
+    });
+  });
+
+  describe('error handling', () => {
+    it('rethrows DynamoDB errors', async () => {
+      mockAuthenticate.mockResolvedValue({ success: true, context: mockAuthContext });
+      mockRepo.listExpenses.mockRejectedValue(new Error('DynamoDB service unavailable'));
+
+      const handler = createDashboardReimbursementsHandler({
+        repo: mockRepo as unknown as ExpenseRepository,
+        authenticate: mockAuthenticate,
+      });
+
+      await expect(handler(makeEvent())).rejects.toThrow('DynamoDB service unavailable');
+    });
+  });
+
+  describe('response format', () => {
+    it('sets content-type to application/json', async () => {
+      mockAuthenticate.mockResolvedValue({ success: true, context: mockAuthContext });
+      mockRepo.listExpenses.mockResolvedValue([]);
+
+      const handler = createDashboardReimbursementsHandler({
+        repo: mockRepo as unknown as ExpenseRepository,
+        authenticate: mockAuthenticate,
+      });
+
+      const result = await handler(makeEvent());
+
+      expect(result.headers).toEqual(
+        expect.objectContaining({ 'content-type': 'application/json' }),
+      );
+    });
+  });
+});

--- a/infra/lib/api-stack.ts
+++ b/infra/lib/api-stack.ts
@@ -174,7 +174,7 @@ export class ApiStack extends cdk.Stack {
         method: HttpMethod.GET,
         path: '/dashboard/reimbursements',
         description: 'Reimbursement summary dashboard',
-        entry: path.join(HANDLERS_DIR, 'stub.handler.ts'),
+        entry: path.join(HANDLERS_DIR, 'dashboard/reimbursements.handler.ts'),
         dynamoAccess: 'read',
       },
       {


### PR DESCRIPTION
## Summary

- Replaces the 501 stub at `GET /dashboard/reimbursements` with a real handler
- Fetches unreimbursed expenses via `repo.listExpenses(accountId, { reimbursed: false })` and aggregates by `paidBy` into `ReimbursementSummary` objects
- Follows the existing factory pattern with dependency injection (matching `expenses/list.ts`)

## Changes

- **New:** `api/src/handlers/dashboard/reimbursements.ts` — Core handler logic with DI
- **New:** `api/src/handlers/dashboard/reimbursements.handler.ts` — Lambda entry point
- **New:** `api/test/handlers/dashboard/reimbursements.test.ts` — 8 unit tests (TDD)
- **Modified:** `infra/lib/api-stack.ts` — Updated entry from `stub.handler.ts` to `dashboard/reimbursements.handler.ts`

## Test plan

- [x] 8 unit tests: auth (401), empty summaries, single payer, multiple payers, aggregation correctness, error rethrow, response format
- [x] Full API test suite passes (260 tests)
- [x] Full infra test suite passes (119 tests)
- [x] TypeScript strict mode clean

Closes #144 (backend portion)

🤖 Generated with [Claude Code](https://claude.com/claude-code)