### PR TITLE
fix: keep ephemeral environment on Playwright failure (#145)

### DIFF
--- a/.github/workflows/ephemeral-e2e.yml
+++ b/.github/workflows/ephemeral-e2e.yml
@@ -28,6 +28,7 @@ jobs:
       user-pool-id: ${{ steps.outputs.outputs.user-pool-id }}
       client-id: ${{ steps.outputs.outputs.client-id }}
       table-name: ${{ steps.outputs.outputs.table-name }}
+      infra-ok: ${{ steps.infra-health.outputs.infra-ok }}
 
     steps:
       - name: Check required secrets
@@ -215,6 +216,11 @@ jobs:
 
           echo "API smoke test passed"
 
+      - name: Mark infrastructure as healthy
+        id: infra-health
+        if: success()
+        run: echo "infra-ok=true" >> "$GITHUB_OUTPUT"
+
       - name: Install Playwright browsers
         working-directory: web
         run: npx playwright install --with-deps chromium
@@ -285,7 +291,9 @@ jobs:
   cleanup-on-failure:
     runs-on: ubuntu-latest
     needs: deploy-and-test
-    if: failure()
+    # Only clean up when infrastructure steps failed (CDK deploy, seed, smoke test).
+    # When only Playwright tests fail, keep the environment alive for debugging.
+    if: ${{ failure() && needs.deploy-and-test.outputs.infra-ok != 'true' }}
     environment: dev
 
     steps:


### PR DESCRIPTION
## Summary
- Added an `infra-health` step after the API smoke test that sets `infra-ok=true` as a job output
- Changed `cleanup-on-failure` job condition to only run when infrastructure steps fail (CDK deploy, seed, smoke test)
- When only Playwright E2E tests fail, the ephemeral environment is preserved for debugging

## Test plan
- [ ] All unit tests pass
- [ ] When Playwright fails but infra is healthy, environment stays alive
- [ ] When CDK deploy or smoke test fails, environment is cleaned up

Closes #145

Generated with [Claude Code](https://claude.com/claude-code)