### PR TITLE
feat: make Dashboard resilient to partial API failures (#144)

### DIFF
--- a/web/e2e/02-dashboard.spec.ts
+++ b/web/e2e/02-dashboard.spec.ts
@@ -7,8 +7,7 @@ test.describe('Dashboard', () => {
     await login(page);
   });
 
-  // Skip: /dashboard/reimbursements is a 501 stub; Promise.all fails entirely. See #144
-  test.skip('displays recent expenses section with seeded data', async ({ page }) => {
+  test('displays recent expenses section with seeded data', async ({ page }) => {
     // Wait for data to load — "Recent Expenses" heading only appears when data exists
     await expect(
       page.getByRole('heading', { name: 'Recent Expenses' }),
@@ -20,8 +19,7 @@ test.describe('Dashboard', () => {
     }
   });
 
-  // Skip: /dashboard/reimbursements is a 501 stub; Promise.all fails entirely. See #144
-  test.skip('displays reimbursement summary', async ({ page }) => {
+  test('displays reimbursement summary', async ({ page }) => {
     // Wait for data to load — "Total Unreimbursed" only appears when data exists
     await expect(
       page.getByText('Total Unreimbursed'),
@@ -50,8 +48,7 @@ test.describe('Dashboard', () => {
     ).toBeVisible();
   });
 
-  // Skip: /dashboard/reimbursements is a 501 stub; Promise.all fails entirely. See #144
-  test.skip('displays formatted amounts for seeded expenses', async ({ page }) => {
+  test('displays formatted amounts for seeded expenses', async ({ page }) => {
     // Wait for data to load
     await expect(
       page.getByRole('heading', { name: 'Recent Expenses' }),

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -58,20 +58,24 @@ export function Dashboard() {
   const fetchData = useCallback(async () => {
     setIsLoading(true);
     setError(null);
-    try {
-      const [summaryData, expenseData] = await Promise.all([
-        getReimbursementSummaries(),
-        listExpenses(),
-      ]);
-      setSummaries(summaryData);
-      setRecentExpenses(expenseData.slice(0, 5));
-    } catch (err: unknown) {
-      const message =
-        err instanceof Error ? err.message : 'Failed to load dashboard data';
-      setError(message);
-    } finally {
-      setIsLoading(false);
+    const [summaryResult, expenseResult] = await Promise.allSettled([
+      getReimbursementSummaries(),
+      listExpenses(),
+    ]);
+
+    const summaryData =
+      summaryResult.status === 'fulfilled' ? summaryResult.value : [];
+    const expenseData =
+      expenseResult.status === 'fulfilled' ? expenseResult.value : [];
+
+    setSummaries(summaryData);
+    setRecentExpenses(expenseData.slice(0, 5));
+
+    if (summaryResult.status === 'rejected' && expenseResult.status === 'rejected') {
+      setError('Failed to load dashboard data');
     }
+
+    setIsLoading(false);
   }, []);
 
   useEffect(() => {

--- a/web/test/accessibility.test.tsx
+++ b/web/test/accessibility.test.tsx
@@ -262,6 +262,7 @@ describe('Accessibility', () => {
       mockGetReimbursementSummaries.mockRejectedValue(
         new Error('Network error'),
       );
+      mockListExpenses.mockRejectedValue(new Error('Network error'));
       renderWithShell('/');
       await waitFor(() => {
         expect(screen.getByRole('alert')).toBeInTheDocument();

--- a/web/test/pages/Dashboard.test.tsx
+++ b/web/test/pages/Dashboard.test.tsx
@@ -258,14 +258,66 @@ describe('Dashboard Page', () => {
     });
   });
 
-  describe('Error handling', () => {
-    it('shows error message when reimbursement fetch fails', async () => {
+  describe('Error handling — partial failures (Promise.allSettled)', () => {
+    it('shows error banner only when BOTH API calls fail', async () => {
       mockGetReimbursementSummaries.mockRejectedValue(new Error('Network error'));
+      mockListExpenses.mockRejectedValue(new Error('Network error'));
 
       renderDashboard();
       await waitFor(() => {
+        expect(screen.getByRole('alert')).toBeInTheDocument();
         expect(screen.getByText(/failed to load/i)).toBeInTheDocument();
       });
+    });
+
+    it('shows expenses when only reimbursement summaries fail', async () => {
+      mockGetReimbursementSummaries.mockRejectedValue(new Error('Server error'));
+      mockListExpenses.mockResolvedValue(mockRecentExpenses());
+
+      renderDashboard();
+      await waitFor(() => {
+        expect(screen.getByText('Office Depot')).toBeInTheDocument();
+        expect(screen.getByText('Amazon')).toBeInTheDocument();
+      });
+      // No error banner
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    });
+
+    it('shows reimbursement data when only expenses fail', async () => {
+      mockGetReimbursementSummaries.mockResolvedValue(mockSummaries());
+      mockListExpenses.mockRejectedValue(new Error('Server error'));
+
+      renderDashboard();
+      await waitFor(() => {
+        expect(screen.getByText('John Doe')).toBeInTheDocument();
+        expect(screen.getByText('Jane Smith')).toBeInTheDocument();
+      });
+      // No error banner
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    });
+
+    it('defaults summaries to empty array when summaries fail', async () => {
+      mockGetReimbursementSummaries.mockRejectedValue(new Error('fail'));
+      mockListExpenses.mockResolvedValue(mockRecentExpenses());
+
+      renderDashboard();
+      await waitFor(() => {
+        expect(screen.getByText('Office Depot')).toBeInTheDocument();
+      });
+      // Total unreimbursed should be $0.00 since summaries defaulted to []
+      expect(screen.queryByText('$195.50')).not.toBeInTheDocument();
+    });
+
+    it('defaults expenses to empty array when expenses fail', async () => {
+      mockGetReimbursementSummaries.mockResolvedValue(mockSummaries());
+      mockListExpenses.mockRejectedValue(new Error('fail'));
+
+      renderDashboard();
+      await waitFor(() => {
+        expect(screen.getByText('John Doe')).toBeInTheDocument();
+      });
+      // No recent expenses section
+      expect(screen.queryByText('Office Depot')).not.toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
## Summary
- Change `Promise.all` to `Promise.allSettled` in Dashboard's `fetchData` so a single API failure doesn't take down the entire page
- Default to empty arrays when individual calls (summaries or expenses) fail; only show error banner when **both** fail
- Unskip 3 E2E dashboard tests that were blocked by the `/dashboard/reimbursements` 501 stub (now implemented in PR #154)
- Update accessibility test to match new partial-failure behavior (both calls must fail to trigger alert)

## Test plan
- [x] 5 new unit tests covering partial failure scenarios (one fails, other succeeds; both fail)
- [x] All 25 Dashboard unit tests pass
- [x] Accessibility tests pass (54 total)
- [x] Full monorepo test suite passes (api, web, infra)
- [x] TypeScript strict check clean
- [x] E2E tests will validate in ephemeral environment (3 unskipped tests)

Closes #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)