### PR TITLE
feat: capture demo screenshots in E2E workflow (#150)

### DIFF
--- a/.github/workflows/ephemeral-e2e.yml
+++ b/.github/workflows/ephemeral-e2e.yml
@@ -234,6 +234,22 @@ jobs:
           E2E_PASSWORD: ${{ secrets.E2E_TEST_PASSWORD }}
         run: npx playwright test --reporter=html
 
+      - name: Capture demo screenshots
+        if: success()
+        env:
+          DEMO_EMAIL: e2e-test@abletracker.local
+          DEMO_PASSWORD: ${{ secrets.E2E_TEST_PASSWORD }}
+          DEMO_URL: ${{ steps.outputs.outputs.website-url }}
+        run: node docs/demos/capture-screenshots.mjs
+
+      - name: Upload demo screenshots
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: demo-screenshots-pr-${{ env.PR_NUMBER }}
+          path: docs/demos/screenshots/
+          retention-days: 30
+
       - name: Upload Playwright report
         if: always()
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- Added a "Capture demo screenshots" step after Playwright tests pass in the ephemeral E2E workflow
- Uses the existing `docs/demos/capture-screenshots.mjs` script with ephemeral environment credentials
- Uploads screenshots as a build artifact (`demo-screenshots-pr-<N>`) with 30-day retention

## Test plan
- [ ] All unit tests pass
- [ ] Screenshot step only runs when Playwright tests pass (`if: success()`)
- [ ] Screenshots uploaded as artifact in next ephemeral E2E run

Closes #150

Generated with [Claude Code](https://claude.com/claude-code)