### PR TITLE
fix: add git worktree prune to agent worktree instructions (#159)

### DIFF
--- a/.claude/skills/plan-next-sprint/SKILL.md
+++ b/.claude/skills/plan-next-sprint/SKILL.md
@@ -237,6 +237,7 @@ Include this block verbatim in every implementing agent's prompt:
 copy of the repository just for you. Your working directory is already set to your
 worktree root. No other agent shares this directory.
 - Run `pwd` first to confirm your working directory
+- Run `git worktree prune` to clean up any stale worktree references that could block branch operations
 - Run `git fetch origin main && git rebase origin/main` to get latest code
 - Run `pnpm install` to pick up any new dependencies
 - THEN create your feature branch: `git checkout -b <branch-name>`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,6 +136,14 @@ These are non-negotiable. Every agent must follow them. They are the guardrails 
 - Every PR references the GitHub issue it addresses
 - PRs require passing CI before merge
 
+### Worktree Cleanup
+
+Agent worktrees can become stale when agents finish or fail, leaving branch locks that block other agents from checking out or rebasing those branches.
+
+- **Before creating a new worktree**, always run `git worktree prune` to clean up stale references.
+- **After an agent finishes**, the worktree should be removed with `git worktree remove <path>`. If the worktree directory was already deleted, `git worktree prune` will clean up the dangling reference.
+- **Diagnosing stale worktrees**: Run `git worktree list` to see all active worktrees. If a listed worktree path no longer exists on disk, run `git worktree prune` to remove it.
+
 ## Agent Team
 
 This project uses a 12-agent team. See `.claude/agents/` for individual agent definitions.


### PR DESCRIPTION
## Summary

- Added `### Worktree Cleanup` section to `CLAUDE.md` documenting `git worktree prune`, `git worktree remove`, and `git worktree list` for diagnosing and cleaning up stale agent worktrees
- Added `git worktree prune` as the first step in the worktree instruction template in `.claude/skills/plan-next-sprint/SKILL.md`
- Updated agent worktree memory instructions to include the prune step

## Test plan

- [x] Verify `CLAUDE.md` contains the new Worktree Cleanup section
- [x] Verify `SKILL.md` worktree template includes `git worktree prune` step
- [x] All existing tests pass (no code changes, docs only)

Closes #159

🤖 Generated with [Claude Code](https://claude.com/claude-code)