### PR TITLE
feat: add accountType field for test account isolation (#29)

### DIFF
--- a/api/src/lib/account-repository.ts
+++ b/api/src/lib/account-repository.ts
@@ -1,0 +1,111 @@
+import {
+  DynamoDBDocumentClient,
+  PutCommand,
+  GetCommand,
+  DeleteCommand,
+} from '@aws-sdk/lib-dynamodb';
+import { ulid } from 'ulid';
+import type { Account, AccountType } from './types.js';
+
+/** Key attributes stored on DynamoDB items but not part of the Account domain model. */
+const KEY_ATTRIBUTES = ['PK', 'SK'] as const;
+
+/**
+ * Strip DynamoDB key attributes from a raw item and return a clean Account object.
+ */
+function itemToAccount(item: Record<string, unknown>): Account {
+  const clean: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(item)) {
+    if (!(KEY_ATTRIBUTES as readonly string[]).includes(key)) {
+      clean[key] = value;
+    }
+  }
+  return clean as unknown as Account;
+}
+
+export interface CreateAccountInput {
+  beneficiaryName: string;
+  createdBy: string;
+  accountType?: AccountType;
+}
+
+/**
+ * Repository for ABLE Tracker account metadata stored in a DynamoDB single-table design.
+ *
+ * Key schema:
+ * - PK: ACCOUNT#<accountId>
+ * - SK: META
+ */
+export class AccountRepository {
+  constructor(
+    private readonly client: DynamoDBDocumentClient,
+    private readonly tableName: string,
+  ) {}
+
+  /**
+   * Create a new account. Generates a ULID for the account ID.
+   * Defaults accountType to 'live' if not specified.
+   */
+  async createAccount(input: CreateAccountInput): Promise<Account> {
+    const id = ulid();
+    const now = new Date().toISOString();
+    const accountType: AccountType = input.accountType ?? 'live';
+
+    const account: Account = {
+      id,
+      beneficiaryName: input.beneficiaryName,
+      accountType,
+      createdAt: now,
+      createdBy: input.createdBy,
+    };
+
+    await this.client.send(
+      new PutCommand({
+        TableName: this.tableName,
+        Item: {
+          PK: `ACCOUNT#${id}`,
+          SK: 'META',
+          ...account,
+        },
+      }),
+    );
+
+    return account;
+  }
+
+  /**
+   * Get an account by ID. Returns null if not found.
+   */
+  async getAccount(accountId: string): Promise<Account | null> {
+    const result = await this.client.send(
+      new GetCommand({
+        TableName: this.tableName,
+        Key: {
+          PK: `ACCOUNT#${accountId}`,
+          SK: 'META',
+        },
+      }),
+    );
+
+    if (!result.Item) {
+      return null;
+    }
+
+    return itemToAccount(result.Item as Record<string, unknown>);
+  }
+
+  /**
+   * Delete an account's META item.
+   */
+  async deleteAccount(accountId: string): Promise<void> {
+    await this.client.send(
+      new DeleteCommand({
+        TableName: this.tableName,
+        Key: {
+          PK: `ACCOUNT#${accountId}`,
+          SK: 'META',
+        },
+      }),
+    );
+  }
+}

--- a/api/src/lib/account-repository.ts
+++ b/api/src/lib/account-repository.ts
@@ -6,22 +6,7 @@ import {
 } from '@aws-sdk/lib-dynamodb';
 import { ulid } from 'ulid';
 import type { Account, AccountType } from './types.js';
-
-/** Key attributes stored on DynamoDB items but not part of the Account domain model. */
-const KEY_ATTRIBUTES = ['PK', 'SK'] as const;
-
-/**
- * Strip DynamoDB key attributes from a raw item and return a clean Account object.
- */
-function itemToAccount(item: Record<string, unknown>): Account {
-  const clean: Record<string, unknown> = {};
-  for (const [key, value] of Object.entries(item)) {
-    if (!(KEY_ATTRIBUTES as readonly string[]).includes(key)) {
-      clean[key] = value;
-    }
-  }
-  return clean as unknown as Account;
-}
+import { stripDynamoKeys } from './dynamo-utils.js';
 
 export interface CreateAccountInput {
   beneficiaryName: string;
@@ -91,7 +76,7 @@ export class AccountRepository {
       return null;
     }
 
-    return itemToAccount(result.Item as Record<string, unknown>);
+    return stripDynamoKeys<Account>(result.Item as Record<string, unknown>, ['PK', 'SK']);
   }
 
   /**

--- a/api/src/lib/dynamo-utils.ts
+++ b/api/src/lib/dynamo-utils.ts
@@ -1,0 +1,26 @@
+/**
+ * Strip DynamoDB key/index attributes from a raw item, returning only domain fields.
+ *
+ * DynamoDB items include synthetic key attributes (PK, SK, GSI*) that are not part
+ * of the domain model. This helper removes them so the result can be treated as
+ * the domain type T.
+ *
+ * The cast to T is intentional — DynamoDB document client items are untyped Records,
+ * and after stripping keys the remaining fields match T by convention of how items are stored.
+ *
+ * @param item - Raw DynamoDB item as a Record
+ * @param keysToStrip - Array of attribute names to remove (e.g., ['PK', 'SK'])
+ * @returns The item without the specified key attributes, typed as T
+ */
+export function stripDynamoKeys<T>(
+  item: Record<string, unknown>,
+  keysToStrip: readonly string[],
+): T {
+  const clean: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(item)) {
+    if (!keysToStrip.includes(key)) {
+      clean[key] = value;
+    }
+  }
+  return clean as unknown as T;
+}

--- a/api/src/lib/dynamo.ts
+++ b/api/src/lib/dynamo.ts
@@ -8,22 +8,10 @@ import {
 } from '@aws-sdk/lib-dynamodb';
 import { ulid } from 'ulid';
 import type { AbleCategory, CreateExpenseInput, Expense, ListExpensesFilters } from './types.js';
+import { stripDynamoKeys } from './dynamo-utils.js';
 
-/** Key attributes stored on every DynamoDB item but not part of the Expense domain model. */
-const KEY_ATTRIBUTES = ['PK', 'SK', 'GSI1PK', 'GSI1SK', 'GSI2PK', 'GSI2SK'] as const;
-
-/**
- * Strip DynamoDB key attributes from a raw item and return a clean Expense object.
- */
-function itemToExpense(item: Record<string, unknown>): Expense {
-  const clean: Record<string, unknown> = {};
-  for (const [key, value] of Object.entries(item)) {
-    if (!(KEY_ATTRIBUTES as readonly string[]).includes(key)) {
-      clean[key] = value;
-    }
-  }
-  return clean as unknown as Expense;
-}
+/** Key attributes stored on every DynamoDB expense item but not part of the domain model. */
+const EXPENSE_KEY_ATTRIBUTES = ['PK', 'SK', 'GSI1PK', 'GSI1SK', 'GSI2PK', 'GSI2SK'] as const;
 
 /**
  * Repository for ABLE Tracker expense items stored in a DynamoDB single-table design.
@@ -103,7 +91,7 @@ export class ExpenseRepository {
       return null;
     }
 
-    return itemToExpense(items[0] as Record<string, unknown>);
+    return stripDynamoKeys<Expense>(items[0] as Record<string, unknown>, EXPENSE_KEY_ATTRIBUTES);
   }
 
   /**
@@ -134,7 +122,7 @@ export class ExpenseRepository {
     );
 
     const items = result.Items ?? [];
-    return items.map((item) => itemToExpense(item as Record<string, unknown>));
+    return items.map((item) => stripDynamoKeys<Expense>(item as Record<string, unknown>, EXPENSE_KEY_ATTRIBUTES));
   }
 
   /**
@@ -155,7 +143,7 @@ export class ExpenseRepository {
     );
 
     const items = result.Items ?? [];
-    return items.map((item) => itemToExpense(item as Record<string, unknown>));
+    return items.map((item) => stripDynamoKeys<Expense>(item as Record<string, unknown>, EXPENSE_KEY_ATTRIBUTES));
   }
 
   /**
@@ -182,7 +170,7 @@ export class ExpenseRepository {
     );
 
     const items = result.Items ?? [];
-    return items.map((item) => itemToExpense(item as Record<string, unknown>));
+    return items.map((item) => stripDynamoKeys<Expense>(item as Record<string, unknown>, EXPENSE_KEY_ATTRIBUTES));
   }
 
   /**
@@ -218,7 +206,7 @@ export class ExpenseRepository {
       }),
     );
 
-    return itemToExpense(result.Attributes as Record<string, unknown>);
+    return stripDynamoKeys<Expense>(result.Attributes as Record<string, unknown>, EXPENSE_KEY_ATTRIBUTES);
   }
 
   /**

--- a/api/src/lib/types.ts
+++ b/api/src/lib/types.ts
@@ -25,9 +25,12 @@ export const ABLE_CATEGORIES = [
   'Basic living expenses',
 ] as const;
 
+export type AccountType = 'live' | 'test';
+
 export interface Account {
   id: string;
   beneficiaryName: string;
+  accountType: AccountType;
   createdAt: string;
   createdBy: string;
 }

--- a/api/src/lib/user-repository.ts
+++ b/api/src/lib/user-repository.ts
@@ -8,22 +8,7 @@ import {
 } from '@aws-sdk/lib-dynamodb';
 import { ulid } from 'ulid';
 import type { User } from './types.js';
-
-/** Key attributes stored on DynamoDB items but not part of the User domain model. */
-const KEY_ATTRIBUTES = ['PK', 'SK'] as const;
-
-/**
- * Strip DynamoDB key attributes from a raw item and return a clean User object.
- */
-function itemToUser(item: Record<string, unknown>): User {
-  const clean: Record<string, unknown> = {};
-  for (const [key, value] of Object.entries(item)) {
-    if (!(KEY_ATTRIBUTES as readonly string[]).includes(key)) {
-      clean[key] = value;
-    }
-  }
-  return clean as unknown as User;
-}
+import { stripDynamoKeys } from './dynamo-utils.js';
 
 export interface CreateUserInput {
   accountId: string;
@@ -93,7 +78,7 @@ export class UserRepository {
       return null;
     }
 
-    return itemToUser(result.Item as Record<string, unknown>);
+    return stripDynamoKeys<User>(result.Item as Record<string, unknown>, ['PK', 'SK']);
   }
 
   /**
@@ -112,7 +97,7 @@ export class UserRepository {
     );
 
     const items = result.Items ?? [];
-    return items.map((item) => itemToUser(item as Record<string, unknown>));
+    return items.map((item) => stripDynamoKeys<User>(item as Record<string, unknown>, ['PK', 'SK']));
   }
 
   /**

--- a/api/src/lib/user-repository.ts
+++ b/api/src/lib/user-repository.ts
@@ -1,0 +1,168 @@
+import {
+  DynamoDBDocumentClient,
+  PutCommand,
+  GetCommand,
+  QueryCommand,
+  DeleteCommand,
+  BatchWriteCommand,
+} from '@aws-sdk/lib-dynamodb';
+import { ulid } from 'ulid';
+import type { User } from './types.js';
+
+/** Key attributes stored on DynamoDB items but not part of the User domain model. */
+const KEY_ATTRIBUTES = ['PK', 'SK'] as const;
+
+/**
+ * Strip DynamoDB key attributes from a raw item and return a clean User object.
+ */
+function itemToUser(item: Record<string, unknown>): User {
+  const clean: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(item)) {
+    if (!(KEY_ATTRIBUTES as readonly string[]).includes(key)) {
+      clean[key] = value;
+    }
+  }
+  return clean as unknown as User;
+}
+
+export interface CreateUserInput {
+  accountId: string;
+  email: string;
+  displayName: string;
+  role: 'owner' | 'authorized_rep';
+  cognitoSub: string;
+}
+
+/**
+ * Repository for ABLE Tracker user items stored in a DynamoDB single-table design.
+ *
+ * Key schema:
+ * - PK: ACCOUNT#<accountId>
+ * - SK: USER#<userId>
+ */
+export class UserRepository {
+  constructor(
+    private readonly client: DynamoDBDocumentClient,
+    private readonly tableName: string,
+  ) {}
+
+  /**
+   * Create a new user. Generates a ULID for the user ID.
+   */
+  async createUser(input: CreateUserInput): Promise<User> {
+    const userId = ulid();
+
+    const user: User = {
+      userId,
+      accountId: input.accountId,
+      email: input.email,
+      displayName: input.displayName,
+      role: input.role,
+      cognitoSub: input.cognitoSub,
+    };
+
+    await this.client.send(
+      new PutCommand({
+        TableName: this.tableName,
+        Item: {
+          PK: `ACCOUNT#${input.accountId}`,
+          SK: `USER#${userId}`,
+          ...user,
+        },
+      }),
+    );
+
+    return user;
+  }
+
+  /**
+   * Get a user by accountId and userId. Returns null if not found.
+   */
+  async getUser(accountId: string, userId: string): Promise<User | null> {
+    const result = await this.client.send(
+      new GetCommand({
+        TableName: this.tableName,
+        Key: {
+          PK: `ACCOUNT#${accountId}`,
+          SK: `USER#${userId}`,
+        },
+      }),
+    );
+
+    if (!result.Item) {
+      return null;
+    }
+
+    return itemToUser(result.Item as Record<string, unknown>);
+  }
+
+  /**
+   * List all users for an account.
+   */
+  async listUsers(accountId: string): Promise<User[]> {
+    const result = await this.client.send(
+      new QueryCommand({
+        TableName: this.tableName,
+        KeyConditionExpression: 'PK = :pk AND begins_with(SK, :skPrefix)',
+        ExpressionAttributeValues: {
+          ':pk': `ACCOUNT#${accountId}`,
+          ':skPrefix': 'USER#',
+        },
+      }),
+    );
+
+    const items = result.Items ?? [];
+    return items.map((item) => itemToUser(item as Record<string, unknown>));
+  }
+
+  /**
+   * Delete a single user.
+   */
+  async deleteUser(accountId: string, userId: string): Promise<void> {
+    await this.client.send(
+      new DeleteCommand({
+        TableName: this.tableName,
+        Key: {
+          PK: `ACCOUNT#${accountId}`,
+          SK: `USER#${userId}`,
+        },
+      }),
+    );
+  }
+
+  /**
+   * Delete all users for an account. Queries first, then batch-deletes.
+   */
+  async deleteAllUsers(accountId: string): Promise<void> {
+    const result = await this.client.send(
+      new QueryCommand({
+        TableName: this.tableName,
+        KeyConditionExpression: 'PK = :pk AND begins_with(SK, :skPrefix)',
+        ExpressionAttributeValues: {
+          ':pk': `ACCOUNT#${accountId}`,
+          ':skPrefix': 'USER#',
+        },
+      }),
+    );
+
+    const items = result.Items ?? [];
+    if (items.length === 0) {
+      return;
+    }
+
+    await this.client.send(
+      new BatchWriteCommand({
+        RequestItems: {
+          [this.tableName]: items.map((item) => ({
+            DeleteRequest: {
+              Key: {
+                PK: `ACCOUNT#${accountId}`,
+                SK: (item as Record<string, unknown>)['SK'] as string,
+              },
+            },
+          })),
+        },
+      }),
+    );
+  }
+}

--- a/api/src/middleware/auth.ts
+++ b/api/src/middleware/auth.ts
@@ -10,6 +10,7 @@ export interface TokenClaims {
   'custom:accountId': string;
   'custom:displayName': string;
   'custom:role': string;
+  'custom:accountType'?: string;
 }
 
 /**
@@ -21,6 +22,7 @@ export interface AuthContext {
   email: string;
   displayName: string;
   role: 'owner' | 'authorized_rep';
+  accountType: 'live' | 'test';
 }
 
 /**
@@ -131,12 +133,15 @@ export function createAuthMiddleware(
         return forbidden('Forbidden');
       }
 
+      const accountType = claims['custom:accountType'] === 'test' ? 'test' : 'live';
+
       const context: AuthContext = {
         userId: claims.sub,
         accountId,
         email: claims.email,
         displayName: claims['custom:displayName'],
         role: role as AuthContext['role'],
+        accountType,
       };
 
       return { success: true, context };
@@ -229,12 +234,15 @@ export function extractAuthContext(event: APIGatewayProxyEventV2): AuthResult {
   }
 
   // Build the authenticated context
+  const accountType = claims['custom:accountType'] === 'test' ? 'test' : 'live';
+
   const context: AuthContext = {
     userId: claims['sub'],
     accountId: claims['custom:accountId'],
     email: claims['email'],
     displayName: claims['custom:displayName'] ?? '',
     role: role as AuthContext['role'],
+    accountType,
   };
 
   return { success: true, context };

--- a/api/src/middleware/auth.ts
+++ b/api/src/middleware/auth.ts
@@ -10,6 +10,7 @@ export interface TokenClaims {
   'custom:accountId': string;
   'custom:displayName': string;
   'custom:role': string;
+  // Optional: absent from tokens issued before accountType was introduced. Defaults to 'live' in AuthContext.
   'custom:accountType'?: string;
 }
 
@@ -133,6 +134,7 @@ export function createAuthMiddleware(
         return forbidden('Forbidden');
       }
 
+      // Default to 'live' for backwards compat with tokens that predate the accountType claim
       const accountType = claims['custom:accountType'] === 'test' ? 'test' : 'live';
 
       const context: AuthContext = {

--- a/api/test/lib/account-repository.test.ts
+++ b/api/test/lib/account-repository.test.ts
@@ -1,0 +1,237 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { mockClient } from 'aws-sdk-client-mock';
+import {
+  DynamoDBDocumentClient,
+  PutCommand,
+  GetCommand,
+  DeleteCommand,
+} from '@aws-sdk/lib-dynamodb';
+import { AccountRepository } from '../../src/lib/account-repository.js';
+import type { Account, AccountType } from '../../src/lib/types.js';
+
+// Mock ulid to return a deterministic value
+vi.mock('ulid', () => ({
+  ulid: () => 'MOCK_ACCT_ULID_01',
+}));
+
+const TABLE_NAME = 'able-tracker-test';
+const ddbMock = mockClient(DynamoDBDocumentClient);
+
+beforeEach(() => {
+  ddbMock.reset();
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date('2025-03-15T10:00:00.000Z'));
+});
+
+describe('AccountRepository', () => {
+  describe('createAccount', () => {
+    it('stores account with correct PK=ACCOUNT#<id> and SK=META', async () => {
+      ddbMock.on(PutCommand).resolves({});
+
+      const repo = new AccountRepository(ddbMock as unknown as DynamoDBDocumentClient, TABLE_NAME);
+      await repo.createAccount({
+        beneficiaryName: 'Jane Doe',
+        createdBy: 'user-admin',
+      });
+
+      const putCall = ddbMock.commandCalls(PutCommand)[0];
+      const item = putCall.args[0].input.Item;
+      expect(item).toBeDefined();
+      expect(item!['PK']).toBe('ACCOUNT#MOCK_ACCT_ULID_01');
+      expect(item!['SK']).toBe('META');
+    });
+
+    it('defaults accountType to "live" when not specified', async () => {
+      ddbMock.on(PutCommand).resolves({});
+
+      const repo = new AccountRepository(ddbMock as unknown as DynamoDBDocumentClient, TABLE_NAME);
+      const account = await repo.createAccount({
+        beneficiaryName: 'Jane Doe',
+        createdBy: 'user-admin',
+      });
+
+      expect(account.accountType).toBe('live');
+
+      const putCall = ddbMock.commandCalls(PutCommand)[0];
+      const item = putCall.args[0].input.Item;
+      expect(item!['accountType']).toBe('live');
+    });
+
+    it('stores accountType as "test" when specified', async () => {
+      ddbMock.on(PutCommand).resolves({});
+
+      const repo = new AccountRepository(ddbMock as unknown as DynamoDBDocumentClient, TABLE_NAME);
+      const account = await repo.createAccount({
+        beneficiaryName: 'Test Beneficiary',
+        createdBy: 'user-admin',
+        accountType: 'test',
+      });
+
+      expect(account.accountType).toBe('test');
+
+      const putCall = ddbMock.commandCalls(PutCommand)[0];
+      const item = putCall.args[0].input.Item;
+      expect(item!['accountType']).toBe('test');
+    });
+
+    it('generates a ULID for the account id', async () => {
+      ddbMock.on(PutCommand).resolves({});
+
+      const repo = new AccountRepository(ddbMock as unknown as DynamoDBDocumentClient, TABLE_NAME);
+      const account = await repo.createAccount({
+        beneficiaryName: 'Jane Doe',
+        createdBy: 'user-admin',
+      });
+
+      expect(account.id).toBe('MOCK_ACCT_ULID_01');
+    });
+
+    it('sets createdAt to current ISO timestamp', async () => {
+      ddbMock.on(PutCommand).resolves({});
+
+      const repo = new AccountRepository(ddbMock as unknown as DynamoDBDocumentClient, TABLE_NAME);
+      const account = await repo.createAccount({
+        beneficiaryName: 'Jane Doe',
+        createdBy: 'user-admin',
+      });
+
+      expect(account.createdAt).toBe('2025-03-15T10:00:00.000Z');
+    });
+
+    it('returns a complete Account object', async () => {
+      ddbMock.on(PutCommand).resolves({});
+
+      const repo = new AccountRepository(ddbMock as unknown as DynamoDBDocumentClient, TABLE_NAME);
+      const account = await repo.createAccount({
+        beneficiaryName: 'Jane Doe',
+        createdBy: 'user-admin',
+        accountType: 'test',
+      });
+
+      expect(account).toEqual({
+        id: 'MOCK_ACCT_ULID_01',
+        beneficiaryName: 'Jane Doe',
+        accountType: 'test',
+        createdAt: '2025-03-15T10:00:00.000Z',
+        createdBy: 'user-admin',
+      });
+    });
+
+    it('uses the correct table name', async () => {
+      ddbMock.on(PutCommand).resolves({});
+
+      const repo = new AccountRepository(ddbMock as unknown as DynamoDBDocumentClient, TABLE_NAME);
+      await repo.createAccount({
+        beneficiaryName: 'Jane Doe',
+        createdBy: 'user-admin',
+      });
+
+      const putCall = ddbMock.commandCalls(PutCommand)[0];
+      expect(putCall.args[0].input.TableName).toBe(TABLE_NAME);
+    });
+  });
+
+  describe('getAccount', () => {
+    it('returns account when found', async () => {
+      const storedItem = {
+        PK: 'ACCOUNT#acct-123',
+        SK: 'META',
+        id: 'acct-123',
+        beneficiaryName: 'Jane Doe',
+        accountType: 'live' as AccountType,
+        createdAt: '2025-03-15T10:00:00.000Z',
+        createdBy: 'user-admin',
+      };
+
+      ddbMock.on(GetCommand).resolves({ Item: storedItem });
+
+      const repo = new AccountRepository(ddbMock as unknown as DynamoDBDocumentClient, TABLE_NAME);
+      const account = await repo.getAccount('acct-123');
+
+      expect(account).not.toBeNull();
+      expect(account!.id).toBe('acct-123');
+      expect(account!.beneficiaryName).toBe('Jane Doe');
+      expect(account!.accountType).toBe('live');
+      expect(account!.createdBy).toBe('user-admin');
+    });
+
+    it('returns null when account not found', async () => {
+      ddbMock.on(GetCommand).resolves({ Item: undefined });
+
+      const repo = new AccountRepository(ddbMock as unknown as DynamoDBDocumentClient, TABLE_NAME);
+      const account = await repo.getAccount('nonexistent');
+
+      expect(account).toBeNull();
+    });
+
+    it('queries with correct PK and SK', async () => {
+      ddbMock.on(GetCommand).resolves({ Item: undefined });
+
+      const repo = new AccountRepository(ddbMock as unknown as DynamoDBDocumentClient, TABLE_NAME);
+      await repo.getAccount('acct-456');
+
+      const getCall = ddbMock.commandCalls(GetCommand)[0];
+      expect(getCall.args[0].input.Key).toEqual({
+        PK: 'ACCOUNT#acct-456',
+        SK: 'META',
+      });
+    });
+
+    it('strips key attributes from returned account', async () => {
+      const storedItem = {
+        PK: 'ACCOUNT#acct-123',
+        SK: 'META',
+        id: 'acct-123',
+        beneficiaryName: 'Jane Doe',
+        accountType: 'test' as AccountType,
+        createdAt: '2025-03-15T10:00:00.000Z',
+        createdBy: 'user-admin',
+      };
+
+      ddbMock.on(GetCommand).resolves({ Item: storedItem });
+
+      const repo = new AccountRepository(ddbMock as unknown as DynamoDBDocumentClient, TABLE_NAME);
+      const account = await repo.getAccount('acct-123');
+
+      expect(account).not.toBeNull();
+      // Should not have PK/SK keys
+      expect((account as Record<string, unknown>)['PK']).toBeUndefined();
+      expect((account as Record<string, unknown>)['SK']).toBeUndefined();
+    });
+
+    it('returns accountType field', async () => {
+      const storedItem = {
+        PK: 'ACCOUNT#acct-123',
+        SK: 'META',
+        id: 'acct-123',
+        beneficiaryName: 'Test Account',
+        accountType: 'test' as AccountType,
+        createdAt: '2025-03-15T10:00:00.000Z',
+        createdBy: 'user-admin',
+      };
+
+      ddbMock.on(GetCommand).resolves({ Item: storedItem });
+
+      const repo = new AccountRepository(ddbMock as unknown as DynamoDBDocumentClient, TABLE_NAME);
+      const account = await repo.getAccount('acct-123');
+
+      expect(account!.accountType).toBe('test');
+    });
+  });
+
+  describe('deleteAccount', () => {
+    it('deletes account with correct PK and SK', async () => {
+      ddbMock.on(DeleteCommand).resolves({});
+
+      const repo = new AccountRepository(ddbMock as unknown as DynamoDBDocumentClient, TABLE_NAME);
+      await repo.deleteAccount('acct-789');
+
+      const deleteCall = ddbMock.commandCalls(DeleteCommand)[0];
+      expect(deleteCall.args[0].input.Key).toEqual({
+        PK: 'ACCOUNT#acct-789',
+        SK: 'META',
+      });
+      expect(deleteCall.args[0].input.TableName).toBe(TABLE_NAME);
+    });
+  });
+});

--- a/api/test/lib/dynamo-utils.test.ts
+++ b/api/test/lib/dynamo-utils.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { stripDynamoKeys } from '../../src/lib/dynamo-utils.js';
+
+interface TestDomain {
+  id: string;
+  name: string;
+  value: number;
+}
+
+describe('stripDynamoKeys', () => {
+  it('strips PK and SK from an item', () => {
+    const item = { PK: 'ACCOUNT#123', SK: 'META', id: '123', name: 'Test' };
+    const result = stripDynamoKeys<TestDomain>(item, ['PK', 'SK']);
+    expect(result).toEqual({ id: '123', name: 'Test' });
+  });
+
+  it('strips GSI key attributes', () => {
+    const item = {
+      PK: 'ACCOUNT#123',
+      SK: 'EXP#2025-01-01#abc',
+      GSI1PK: 'ACCOUNT#123',
+      GSI1SK: 'CAT#Housing#2025-01-01',
+      GSI2PK: 'ACCOUNT#123',
+      GSI2SK: 'PAID#user1#0#2025-01-01',
+      id: '123',
+      name: 'Test',
+      value: 42,
+    };
+    const keysToStrip = ['PK', 'SK', 'GSI1PK', 'GSI1SK', 'GSI2PK', 'GSI2SK'];
+    const result = stripDynamoKeys<TestDomain>(item, keysToStrip);
+    expect(result).toEqual({ id: '123', name: 'Test', value: 42 });
+  });
+
+  it('preserves all non-key attributes', () => {
+    const item = { PK: 'X', SK: 'Y', a: 1, b: 'two', c: true, d: null };
+    const result = stripDynamoKeys<Record<string, unknown>>(item, ['PK', 'SK']);
+    expect(result).toEqual({ a: 1, b: 'two', c: true, d: null });
+  });
+
+  it('returns empty object when all attributes are keys', () => {
+    const item = { PK: 'ACCOUNT#123', SK: 'META' };
+    const result = stripDynamoKeys<Record<string, unknown>>(item, ['PK', 'SK']);
+    expect(result).toEqual({});
+  });
+
+  it('returns item unchanged when no keys match', () => {
+    const item = { id: '123', name: 'Test', value: 42 };
+    const result = stripDynamoKeys<TestDomain>(item, ['PK', 'SK']);
+    expect(result).toEqual({ id: '123', name: 'Test', value: 42 });
+  });
+});

--- a/api/test/lib/user-repository.test.ts
+++ b/api/test/lib/user-repository.test.ts
@@ -1,0 +1,263 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { mockClient } from 'aws-sdk-client-mock';
+import {
+  DynamoDBDocumentClient,
+  PutCommand,
+  GetCommand,
+  QueryCommand,
+  DeleteCommand,
+  BatchWriteCommand,
+} from '@aws-sdk/lib-dynamodb';
+import { UserRepository } from '../../src/lib/user-repository.js';
+import type { User } from '../../src/lib/types.js';
+
+// Mock ulid to return a deterministic value
+vi.mock('ulid', () => ({
+  ulid: () => 'MOCK_USER_ULID_01',
+}));
+
+const TABLE_NAME = 'able-tracker-test';
+const ddbMock = mockClient(DynamoDBDocumentClient);
+
+beforeEach(() => {
+  ddbMock.reset();
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date('2025-03-15T10:00:00.000Z'));
+});
+
+function makeStoredUser(overrides: Partial<User> = {}): Record<string, unknown> {
+  const user: User = {
+    userId: 'MOCK_USER_ULID_01',
+    accountId: 'acct-123',
+    email: 'alice@example.com',
+    displayName: 'Alice Smith',
+    role: 'owner',
+    cognitoSub: 'cognito-sub-abc',
+    ...overrides,
+  };
+  return {
+    PK: `ACCOUNT#${user.accountId}`,
+    SK: `USER#${user.userId}`,
+    ...user,
+  };
+}
+
+describe('UserRepository', () => {
+  describe('createUser', () => {
+    it('stores user with correct PK=ACCOUNT#<accountId> and SK=USER#<userId>', async () => {
+      ddbMock.on(PutCommand).resolves({});
+
+      const repo = new UserRepository(ddbMock as unknown as DynamoDBDocumentClient, TABLE_NAME);
+      await repo.createUser({
+        accountId: 'acct-123',
+        email: 'alice@example.com',
+        displayName: 'Alice Smith',
+        role: 'owner',
+        cognitoSub: 'cognito-sub-abc',
+      });
+
+      const putCall = ddbMock.commandCalls(PutCommand)[0];
+      const item = putCall.args[0].input.Item;
+      expect(item!['PK']).toBe('ACCOUNT#acct-123');
+      expect(item!['SK']).toBe('USER#MOCK_USER_ULID_01');
+    });
+
+    it('generates a ULID for userId', async () => {
+      ddbMock.on(PutCommand).resolves({});
+
+      const repo = new UserRepository(ddbMock as unknown as DynamoDBDocumentClient, TABLE_NAME);
+      const user = await repo.createUser({
+        accountId: 'acct-123',
+        email: 'alice@example.com',
+        displayName: 'Alice Smith',
+        role: 'owner',
+        cognitoSub: 'cognito-sub-abc',
+      });
+
+      expect(user.userId).toBe('MOCK_USER_ULID_01');
+    });
+
+    it('returns a complete User object', async () => {
+      ddbMock.on(PutCommand).resolves({});
+
+      const repo = new UserRepository(ddbMock as unknown as DynamoDBDocumentClient, TABLE_NAME);
+      const user = await repo.createUser({
+        accountId: 'acct-123',
+        email: 'alice@example.com',
+        displayName: 'Alice Smith',
+        role: 'owner',
+        cognitoSub: 'cognito-sub-abc',
+      });
+
+      expect(user).toEqual({
+        userId: 'MOCK_USER_ULID_01',
+        accountId: 'acct-123',
+        email: 'alice@example.com',
+        displayName: 'Alice Smith',
+        role: 'owner',
+        cognitoSub: 'cognito-sub-abc',
+      });
+    });
+
+    it('uses the correct table name', async () => {
+      ddbMock.on(PutCommand).resolves({});
+
+      const repo = new UserRepository(ddbMock as unknown as DynamoDBDocumentClient, TABLE_NAME);
+      await repo.createUser({
+        accountId: 'acct-123',
+        email: 'alice@example.com',
+        displayName: 'Alice Smith',
+        role: 'owner',
+        cognitoSub: 'cognito-sub-abc',
+      });
+
+      const putCall = ddbMock.commandCalls(PutCommand)[0];
+      expect(putCall.args[0].input.TableName).toBe(TABLE_NAME);
+    });
+  });
+
+  describe('getUser', () => {
+    it('returns user when found', async () => {
+      ddbMock.on(GetCommand).resolves({ Item: makeStoredUser() });
+
+      const repo = new UserRepository(ddbMock as unknown as DynamoDBDocumentClient, TABLE_NAME);
+      const user = await repo.getUser('acct-123', 'MOCK_USER_ULID_01');
+
+      expect(user).not.toBeNull();
+      expect(user!.userId).toBe('MOCK_USER_ULID_01');
+      expect(user!.email).toBe('alice@example.com');
+    });
+
+    it('returns null when user not found', async () => {
+      ddbMock.on(GetCommand).resolves({ Item: undefined });
+
+      const repo = new UserRepository(ddbMock as unknown as DynamoDBDocumentClient, TABLE_NAME);
+      const user = await repo.getUser('acct-123', 'nonexistent');
+
+      expect(user).toBeNull();
+    });
+
+    it('queries with correct PK and SK', async () => {
+      ddbMock.on(GetCommand).resolves({ Item: undefined });
+
+      const repo = new UserRepository(ddbMock as unknown as DynamoDBDocumentClient, TABLE_NAME);
+      await repo.getUser('acct-456', 'user-789');
+
+      const getCall = ddbMock.commandCalls(GetCommand)[0];
+      expect(getCall.args[0].input.Key).toEqual({
+        PK: 'ACCOUNT#acct-456',
+        SK: 'USER#user-789',
+      });
+    });
+
+    it('strips key attributes from returned user', async () => {
+      ddbMock.on(GetCommand).resolves({ Item: makeStoredUser() });
+
+      const repo = new UserRepository(ddbMock as unknown as DynamoDBDocumentClient, TABLE_NAME);
+      const user = await repo.getUser('acct-123', 'MOCK_USER_ULID_01');
+
+      expect((user as Record<string, unknown>)['PK']).toBeUndefined();
+      expect((user as Record<string, unknown>)['SK']).toBeUndefined();
+    });
+  });
+
+  describe('listUsers', () => {
+    it('returns all users for an account', async () => {
+      const user1 = makeStoredUser({ userId: 'user-1', email: 'alice@example.com' });
+      const user2 = makeStoredUser({ userId: 'user-2', email: 'bob@example.com', role: 'authorized_rep' });
+
+      ddbMock.on(QueryCommand).resolves({ Items: [user1, user2] });
+
+      const repo = new UserRepository(ddbMock as unknown as DynamoDBDocumentClient, TABLE_NAME);
+      const users = await repo.listUsers('acct-123');
+
+      expect(users).toHaveLength(2);
+      expect(users[0].email).toBe('alice@example.com');
+      expect(users[1].email).toBe('bob@example.com');
+    });
+
+    it('returns empty array for account with no users', async () => {
+      ddbMock.on(QueryCommand).resolves({ Items: [] });
+
+      const repo = new UserRepository(ddbMock as unknown as DynamoDBDocumentClient, TABLE_NAME);
+      const users = await repo.listUsers('acct-empty');
+
+      expect(users).toEqual([]);
+    });
+
+    it('queries with correct PK and SK prefix', async () => {
+      ddbMock.on(QueryCommand).resolves({ Items: [] });
+
+      const repo = new UserRepository(ddbMock as unknown as DynamoDBDocumentClient, TABLE_NAME);
+      await repo.listUsers('acct-123');
+
+      const queryCall = ddbMock.commandCalls(QueryCommand)[0];
+      expect(queryCall.args[0].input.KeyConditionExpression).toBe(
+        'PK = :pk AND begins_with(SK, :skPrefix)',
+      );
+      expect(queryCall.args[0].input.ExpressionAttributeValues).toEqual({
+        ':pk': 'ACCOUNT#acct-123',
+        ':skPrefix': 'USER#',
+      });
+    });
+
+    it('strips key attributes from returned users', async () => {
+      ddbMock.on(QueryCommand).resolves({ Items: [makeStoredUser()] });
+
+      const repo = new UserRepository(ddbMock as unknown as DynamoDBDocumentClient, TABLE_NAME);
+      const users = await repo.listUsers('acct-123');
+
+      expect((users[0] as Record<string, unknown>)['PK']).toBeUndefined();
+      expect((users[0] as Record<string, unknown>)['SK']).toBeUndefined();
+    });
+  });
+
+  describe('deleteUser', () => {
+    it('deletes user with correct PK and SK', async () => {
+      ddbMock.on(DeleteCommand).resolves({});
+
+      const repo = new UserRepository(ddbMock as unknown as DynamoDBDocumentClient, TABLE_NAME);
+      await repo.deleteUser('acct-123', 'user-456');
+
+      const deleteCall = ddbMock.commandCalls(DeleteCommand)[0];
+      expect(deleteCall.args[0].input.Key).toEqual({
+        PK: 'ACCOUNT#acct-123',
+        SK: 'USER#user-456',
+      });
+    });
+  });
+
+  describe('deleteAllUsers', () => {
+    it('queries all users then batch-deletes them', async () => {
+      const user1 = makeStoredUser({ userId: 'user-1' });
+      const user2 = makeStoredUser({ userId: 'user-2' });
+
+      ddbMock.on(QueryCommand).resolves({ Items: [user1, user2] });
+      ddbMock.on(BatchWriteCommand).resolves({});
+
+      const repo = new UserRepository(ddbMock as unknown as DynamoDBDocumentClient, TABLE_NAME);
+      await repo.deleteAllUsers('acct-123');
+
+      const batchCall = ddbMock.commandCalls(BatchWriteCommand)[0];
+      const requests = batchCall.args[0].input.RequestItems![TABLE_NAME];
+      expect(requests).toHaveLength(2);
+      expect(requests![0].DeleteRequest!.Key).toEqual({
+        PK: 'ACCOUNT#acct-123',
+        SK: 'USER#user-1',
+      });
+      expect(requests![1].DeleteRequest!.Key).toEqual({
+        PK: 'ACCOUNT#acct-123',
+        SK: 'USER#user-2',
+      });
+    });
+
+    it('does nothing when no users exist', async () => {
+      ddbMock.on(QueryCommand).resolves({ Items: [] });
+
+      const repo = new UserRepository(ddbMock as unknown as DynamoDBDocumentClient, TABLE_NAME);
+      await repo.deleteAllUsers('acct-empty');
+
+      expect(ddbMock.commandCalls(BatchWriteCommand)).toHaveLength(0);
+    });
+  });
+});

--- a/api/test/middleware/auth.test.ts
+++ b/api/test/middleware/auth.test.ts
@@ -477,6 +477,52 @@ describe('createAuthMiddleware', () => {
     });
   });
 
+  describe('accountType extraction', () => {
+    it('extracts accountType from custom:accountType claim', async () => {
+      const claimsWithAccountType: TokenClaims = {
+        ...validClaims,
+        'custom:accountType': 'test',
+      };
+      const verifier = vi.fn<TokenVerifier>().mockResolvedValue(claimsWithAccountType);
+      const middleware = createAuthMiddleware(verifier);
+
+      const event = makeEvent({ authorization: 'Bearer valid-token' });
+      const result = await middleware(event);
+
+      expect(result.success).toBe(true);
+      const ctx = (result as Extract<AuthResult, { success: true }>).context;
+      expect(ctx.accountType).toBe('test');
+    });
+
+    it('defaults accountType to "live" when custom:accountType claim is missing', async () => {
+      const verifier = vi.fn<TokenVerifier>().mockResolvedValue(validClaims);
+      const middleware = createAuthMiddleware(verifier);
+
+      const event = makeEvent({ authorization: 'Bearer valid-token' });
+      const result = await middleware(event);
+
+      expect(result.success).toBe(true);
+      const ctx = (result as Extract<AuthResult, { success: true }>).context;
+      expect(ctx.accountType).toBe('live');
+    });
+
+    it('sets accountType to "live" when custom:accountType claim is "live"', async () => {
+      const claimsWithLive: TokenClaims = {
+        ...validClaims,
+        'custom:accountType': 'live',
+      };
+      const verifier = vi.fn<TokenVerifier>().mockResolvedValue(claimsWithLive);
+      const middleware = createAuthMiddleware(verifier);
+
+      const event = makeEvent({ authorization: 'Bearer valid-token' });
+      const result = await middleware(event);
+
+      expect(result.success).toBe(true);
+      const ctx = (result as Extract<AuthResult, { success: true }>).context;
+      expect(ctx.accountType).toBe('live');
+    });
+  });
+
   describe('case-insensitive header handling', () => {
     it('handles lowercase authorization header', async () => {
       const verifier = vi.fn<TokenVerifier>().mockResolvedValue(validClaims);
@@ -584,6 +630,43 @@ describe('extractAuthContext', () => {
       expect(result.success).toBe(true);
       const ctx = (result as Extract<AuthResult, { success: true }>).context;
       expect(ctx.role).toBe('authorized_rep');
+    });
+  });
+
+  describe('accountType extraction', () => {
+    it('extracts accountType from custom:accountType claim', () => {
+      const claims = {
+        ...validAuthorizerClaims,
+        'custom:accountType': 'test',
+      };
+      const event = makeEventWithAuthorizer(claims);
+      const result = extractAuthContext(event);
+
+      expect(result.success).toBe(true);
+      const ctx = (result as Extract<AuthResult, { success: true }>).context;
+      expect(ctx.accountType).toBe('test');
+    });
+
+    it('defaults accountType to "live" when custom:accountType claim is missing', () => {
+      const event = makeEventWithAuthorizer(validAuthorizerClaims);
+      const result = extractAuthContext(event);
+
+      expect(result.success).toBe(true);
+      const ctx = (result as Extract<AuthResult, { success: true }>).context;
+      expect(ctx.accountType).toBe('live');
+    });
+
+    it('sets accountType to "live" when custom:accountType claim is "live"', () => {
+      const claims = {
+        ...validAuthorizerClaims,
+        'custom:accountType': 'live',
+      };
+      const event = makeEventWithAuthorizer(claims);
+      const result = extractAuthContext(event);
+
+      expect(result.success).toBe(true);
+      const ctx = (result as Extract<AuthResult, { success: true }>).context;
+      expect(ctx.accountType).toBe('live');
     });
   });
 

--- a/infra/lib/auth-stack.ts
+++ b/infra/lib/auth-stack.ts
@@ -36,6 +36,7 @@ export class AuthStack extends cdk.Stack {
       customAttributes: {
         role: new cognito.StringAttribute({ mutable: true }),
         accountId: new cognito.StringAttribute({ mutable: true }),
+        accountType: new cognito.StringAttribute({ mutable: false }),
       },
       removalPolicy,
     });
@@ -52,7 +53,7 @@ export class AuthStack extends cdk.Stack {
           email: true,
           emailVerified: true,
         })
-        .withCustomAttributes('role', 'accountId'),
+        .withCustomAttributes('role', 'accountId', 'accountType'),
       writeAttributes: new cognito.ClientAttributes()
         .withStandardAttributes({
           email: true,

--- a/infra/test/auth-stack.test.ts
+++ b/infra/test/auth-stack.test.ts
@@ -64,6 +64,18 @@ describe('AuthStack', () => {
         ]),
       });
     });
+
+    it('defines custom:accountType as an immutable string attribute in schema', () => {
+      template.hasResourceProperties('AWS::Cognito::UserPool', {
+        Schema: Match.arrayWith([
+          Match.objectLike({
+            Name: 'accountType',
+            AttributeDataType: 'String',
+            Mutable: false,
+          }),
+        ]),
+      });
+    });
   });
 
   describe('App Client', () => {
@@ -110,6 +122,20 @@ describe('AuthStack', () => {
     it('allows clients to read custom:accountId attribute', () => {
       template.hasResourceProperties('AWS::Cognito::UserPoolClient', {
         ReadAttributes: Match.arrayWith(['custom:accountId']),
+      });
+    });
+
+    it('allows clients to read custom:accountType attribute', () => {
+      template.hasResourceProperties('AWS::Cognito::UserPoolClient', {
+        ReadAttributes: Match.arrayWith(['custom:accountType']),
+      });
+    });
+
+    it('does not allow clients to write custom:accountType attribute', () => {
+      template.hasResourceProperties('AWS::Cognito::UserPoolClient', {
+        WriteAttributes: Match.not(
+          Match.arrayWith(['custom:accountType']),
+        ),
       });
     });
   });

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "devDependencies": {
     "husky": "^9.1.7",
-    "playwright": "^1.58.2"
+    "playwright": "^1.58.2",
+    "ulid": "^2.4.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       playwright:
         specifier: ^1.58.2
         version: 1.58.2
+      ulid:
+        specifier: ^2.4.0
+        version: 2.4.0
 
   api:
     dependencies:

--- a/scripts/create-test-account.mjs
+++ b/scripts/create-test-account.mjs
@@ -1,0 +1,224 @@
+#!/usr/bin/env node
+
+// Schema source of truth: api/src/lib/account-repository.ts, api/src/lib/user-repository.ts
+
+/**
+ * Creates a test account in production with account-level isolation.
+ *
+ * This script:
+ * 1. Generates a ULID for the account ID
+ * 2. Creates an Account META item in DynamoDB with accountType='test'
+ * 3. Creates a User item in DynamoDB
+ * 4. Creates a Cognito user with custom:accountType=test
+ * 5. Sets a permanent password
+ *
+ * SAFETY: This script hardcodes accountType='test' — it cannot create live accounts.
+ *
+ * Required environment variables:
+ *   AWS_REGION        — AWS region
+ *   USER_POOL_ID      — Cognito User Pool ID
+ *   TABLE_NAME        — DynamoDB table name
+ *   TEST_EMAIL        — Email for the test user
+ *   TEST_PASSWORD     — Password for the test user (must meet Cognito policy)
+ *   TEST_DISPLAY_NAME — Display name for the test user
+ *   BENEFICIARY_NAME  — Name of the ABLE beneficiary
+ *
+ * Outputs:
+ *   ACCOUNT_ID — The generated test account ID (to stdout and GITHUB_OUTPUT if available)
+ */
+
+import { appendFileSync } from 'node:fs';
+import { execSync } from 'node:child_process';
+import { randomBytes } from 'node:crypto';
+
+const AWS_REGION = requiredEnv('AWS_REGION');
+const USER_POOL_ID = requiredEnv('USER_POOL_ID');
+const TABLE_NAME = requiredEnv('TABLE_NAME');
+const TEST_EMAIL = requiredEnv('TEST_EMAIL');
+const TEST_PASSWORD = requiredEnv('TEST_PASSWORD');
+const TEST_DISPLAY_NAME = process.env.TEST_DISPLAY_NAME || 'Test User';
+const BENEFICIARY_NAME = process.env.BENEFICIARY_NAME || 'Test Beneficiary';
+
+function requiredEnv(name) {
+  const value = process.env[name];
+  if (!value) {
+    console.error(`ERROR: Missing required environment variable: ${name}`);
+    process.exit(1);
+  }
+  return value;
+}
+
+/**
+ * Generate a ULID-like ID. Uses timestamp + random bytes for uniqueness.
+ */
+function generateId() {
+  const time = Date.now().toString(36).toUpperCase();
+  const rand = randomBytes(10).toString('hex').toUpperCase().slice(0, 16);
+  return `${time}${rand}`;
+}
+
+/**
+ * Run an AWS CLI command and return stdout.
+ */
+function awsCli(args) {
+  return execSync(`aws ${args}`, { stdio: 'pipe', encoding: 'utf-8' });
+}
+
+/**
+ * Insert a DynamoDB item via the AWS CLI (DynamoDB JSON format).
+ */
+function dynamoPutItem(item) {
+  const putItemInput = JSON.stringify({
+    TableName: TABLE_NAME,
+    Item: item,
+  });
+
+  execSync(
+    `aws dynamodb put-item --cli-input-json '${putItemInput.replace(/'/g, "'\\''")}'`,
+    { stdio: 'pipe' },
+  );
+}
+
+function createAccountItem(accountId) {
+  console.log('Creating Account META item in DynamoDB...');
+
+  const now = new Date().toISOString();
+  const item = {
+    PK: { S: `ACCOUNT#${accountId}` },
+    SK: { S: 'META' },
+    id: { S: accountId },
+    beneficiaryName: { S: BENEFICIARY_NAME },
+    accountType: { S: 'test' }, // SAFETY: Always 'test'
+    createdAt: { S: now },
+    createdBy: { S: TEST_EMAIL },
+  };
+
+  dynamoPutItem(item);
+  console.log(`  Account created: ${accountId} (accountType=test)`);
+}
+
+function createUserItem(accountId, userId) {
+  console.log('Creating User item in DynamoDB...');
+
+  const item = {
+    PK: { S: `ACCOUNT#${accountId}` },
+    SK: { S: `USER#${userId}` },
+    userId: { S: userId },
+    accountId: { S: accountId },
+    email: { S: TEST_EMAIL },
+    displayName: { S: TEST_DISPLAY_NAME },
+    role: { S: 'owner' },
+    cognitoSub: { S: 'pending-cognito-creation' },
+  };
+
+  dynamoPutItem(item);
+  console.log(`  User created: ${userId} (${TEST_EMAIL})`);
+}
+
+function createCognitoUser(accountId) {
+  console.log('Creating Cognito user...');
+
+  try {
+    awsCli(
+      `cognito-idp admin-create-user --user-pool-id "${USER_POOL_ID}" --username "${TEST_EMAIL}" ` +
+      `--temporary-password "${TEST_PASSWORD}" ` +
+      `--user-attributes ` +
+      `Name=email,Value="${TEST_EMAIL}" ` +
+      `Name=email_verified,Value=true ` +
+      `Name=custom:role,Value=owner ` +
+      `Name=custom:accountId,Value="${accountId}" ` +
+      `Name=custom:accountType,Value=test ` +
+      `--message-action SUPPRESS`,
+    );
+  } catch (err) {
+    if (err.stderr && err.stderr.includes('UsernameExistsException')) {
+      console.log('  User already exists, updating attributes...');
+      awsCli(
+        `cognito-idp admin-update-user-attributes --user-pool-id "${USER_POOL_ID}" --username "${TEST_EMAIL}" ` +
+        `--user-attributes ` +
+        `Name=custom:role,Value=owner ` +
+        `Name=custom:accountId,Value="${accountId}" ` +
+        `Name=custom:accountType,Value=test`,
+      );
+    } else {
+      throw err;
+    }
+  }
+
+  // Set permanent password
+  awsCli(
+    `cognito-idp admin-set-user-password --user-pool-id "${USER_POOL_ID}" --username "${TEST_EMAIL}" --password "${TEST_PASSWORD}" --permanent`,
+  );
+
+  // Get the Cognito sub for the user record
+  const result = awsCli(
+    `cognito-idp admin-get-user --user-pool-id "${USER_POOL_ID}" --username "${TEST_EMAIL}"`,
+  );
+  const userData = JSON.parse(result);
+  const subAttr = (userData.UserAttributes ?? []).find((a) => a.Name === 'sub');
+  const cognitoSub = subAttr ? subAttr.Value : 'unknown';
+
+  console.log(`  Cognito user created: ${TEST_EMAIL} (sub=${cognitoSub})`);
+  return cognitoSub;
+}
+
+function updateUserCognitoSub(accountId, userId, cognitoSub) {
+  console.log('Updating User item with Cognito sub...');
+
+  const updateInput = JSON.stringify({
+    TableName: TABLE_NAME,
+    Key: {
+      PK: { S: `ACCOUNT#${accountId}` },
+      SK: { S: `USER#${userId}` },
+    },
+    UpdateExpression: 'SET cognitoSub = :sub',
+    ExpressionAttributeValues: {
+      ':sub': { S: cognitoSub },
+    },
+  });
+
+  execSync(
+    `aws dynamodb update-item --cli-input-json '${updateInput.replace(/'/g, "'\\''")}'`,
+    { stdio: 'pipe' },
+  );
+
+  console.log(`  Updated cognitoSub=${cognitoSub}`);
+}
+
+function writeOutput(accountId) {
+  const outputFile = process.env.GITHUB_OUTPUT;
+  if (outputFile) {
+    appendFileSync(outputFile, `ACCOUNT_ID=${accountId}\n`);
+    console.log('Wrote ACCOUNT_ID to GITHUB_OUTPUT');
+  }
+  console.log(`\nACCOUNT_ID=${accountId}`);
+}
+
+function main() {
+  console.log('=== Create Test Account ===');
+  console.log(`Region: ${AWS_REGION}`);
+  console.log(`User Pool: ${USER_POOL_ID}`);
+  console.log(`Table: ${TABLE_NAME}`);
+  console.log(`Email: ${TEST_EMAIL}`);
+  console.log(`Beneficiary: ${BENEFICIARY_NAME}`);
+  console.log('');
+
+  const accountId = generateId();
+  const userId = generateId();
+
+  createAccountItem(accountId);
+  createUserItem(accountId, userId);
+  const cognitoSub = createCognitoUser(accountId);
+  updateUserCognitoSub(accountId, userId, cognitoSub);
+  writeOutput(accountId);
+
+  console.log('');
+  console.log('Test account created successfully.');
+}
+
+try {
+  main();
+} catch (err) {
+  console.error('Create test account failed:', err.message);
+  process.exit(1);
+}

--- a/scripts/create-test-account.mjs
+++ b/scripts/create-test-account.mjs
@@ -29,7 +29,7 @@
 
 import { appendFileSync } from 'node:fs';
 import { execSync } from 'node:child_process';
-import { randomBytes } from 'node:crypto';
+import { ulid } from 'ulid';
 
 const AWS_REGION = requiredEnv('AWS_REGION');
 const USER_POOL_ID = requiredEnv('USER_POOL_ID');
@@ -46,15 +46,6 @@ function requiredEnv(name) {
     process.exit(1);
   }
   return value;
-}
-
-/**
- * Generate a ULID-like ID. Uses timestamp + random bytes for uniqueness.
- */
-function generateId() {
-  const time = Date.now().toString(36).toUpperCase();
-  const rand = randomBytes(10).toString('hex').toUpperCase().slice(0, 16);
-  return `${time}${rand}`;
 }
 
 /**
@@ -132,13 +123,13 @@ function createCognitoUser(accountId) {
     );
   } catch (err) {
     if (err.stderr && err.stderr.includes('UsernameExistsException')) {
-      console.log('  User already exists, updating attributes...');
+      // custom:accountType is immutable in Cognito — already set at creation time, so only update mutable attributes
+      console.log('  User already exists, updating mutable attributes...');
       awsCli(
         `cognito-idp admin-update-user-attributes --user-pool-id "${USER_POOL_ID}" --username "${TEST_EMAIL}" ` +
         `--user-attributes ` +
         `Name=custom:role,Value=owner ` +
-        `Name=custom:accountId,Value="${accountId}" ` +
-        `Name=custom:accountType,Value=test`,
+        `Name=custom:accountId,Value="${accountId}"`,
       );
     } else {
       throw err;
@@ -203,8 +194,8 @@ function main() {
   console.log(`Beneficiary: ${BENEFICIARY_NAME}`);
   console.log('');
 
-  const accountId = generateId();
-  const userId = generateId();
+  const accountId = ulid();
+  const userId = ulid();
 
   createAccountItem(accountId);
   createUserItem(accountId, userId);

--- a/scripts/delete-test-account.mjs
+++ b/scripts/delete-test-account.mjs
@@ -1,0 +1,258 @@
+#!/usr/bin/env node
+
+// Schema source of truth: api/src/lib/account-repository.ts, api/src/lib/user-repository.ts
+
+/**
+ * Deletes a test account and all associated data from production.
+ *
+ * SAFETY CHECKS:
+ * - Reads the Account META item and verifies accountType === 'test'
+ * - REFUSES to delete live accounts — exits with error
+ *
+ * This script:
+ * 1. Reads and verifies the Account META item (must be accountType='test')
+ * 2. Queries ALL items under the account partition (expenses, users, meta)
+ * 3. Batch-deletes all DynamoDB items
+ * 4. Deletes S3 objects under receipts/<accountId>/
+ * 5. Finds and deletes Cognito users associated with the account
+ *
+ * Required environment variables:
+ *   AWS_REGION        — AWS region
+ *   USER_POOL_ID      — Cognito User Pool ID
+ *   TABLE_NAME        — DynamoDB table name
+ *   ACCOUNT_ID        — The test account ID to delete
+ *   RECEIPT_BUCKET    — S3 bucket name for receipts (optional — skips S3 cleanup if not set)
+ */
+
+import { execSync } from 'node:child_process';
+
+const AWS_REGION = requiredEnv('AWS_REGION');
+const USER_POOL_ID = requiredEnv('USER_POOL_ID');
+const TABLE_NAME = requiredEnv('TABLE_NAME');
+const ACCOUNT_ID = requiredEnv('ACCOUNT_ID');
+const RECEIPT_BUCKET = process.env.RECEIPT_BUCKET || '';
+
+function requiredEnv(name) {
+  const value = process.env[name];
+  if (!value) {
+    console.error(`ERROR: Missing required environment variable: ${name}`);
+    process.exit(1);
+  }
+  return value;
+}
+
+/**
+ * Run an AWS CLI command and return stdout.
+ */
+function awsCli(args) {
+  return execSync(`aws ${args}`, { stdio: 'pipe', encoding: 'utf-8' });
+}
+
+/**
+ * Read a DynamoDB item by PK and SK.
+ */
+function dynamoGetItem(pk, sk) {
+  const getItemInput = JSON.stringify({
+    TableName: TABLE_NAME,
+    Key: { PK: { S: pk }, SK: { S: sk } },
+  });
+
+  const result = execSync(
+    `aws dynamodb get-item --cli-input-json '${getItemInput.replace(/'/g, "'\\''")}'`,
+    { stdio: 'pipe', encoding: 'utf-8' },
+  );
+
+  const parsed = JSON.parse(result);
+  return parsed.Item ?? null;
+}
+
+/**
+ * Query all items under a partition key.
+ */
+function dynamoQueryPartition(pk) {
+  const queryInput = JSON.stringify({
+    TableName: TABLE_NAME,
+    KeyConditionExpression: 'PK = :pk',
+    ExpressionAttributeValues: {
+      ':pk': { S: pk },
+    },
+  });
+
+  const result = execSync(
+    `aws dynamodb query --cli-input-json '${queryInput.replace(/'/g, "'\\''")}'`,
+    { stdio: 'pipe', encoding: 'utf-8' },
+  );
+
+  const parsed = JSON.parse(result);
+  return parsed.Items ?? [];
+}
+
+/**
+ * Batch-delete DynamoDB items. Handles batches of 25 (DynamoDB limit).
+ */
+function dynamoBatchDelete(items) {
+  const BATCH_SIZE = 25;
+
+  for (let i = 0; i < items.length; i += BATCH_SIZE) {
+    const batch = items.slice(i, i + BATCH_SIZE);
+    const deleteRequests = batch.map((item) => ({
+      DeleteRequest: {
+        Key: {
+          PK: item.PK,
+          SK: item.SK,
+        },
+      },
+    }));
+
+    const batchInput = JSON.stringify({
+      RequestItems: {
+        [TABLE_NAME]: deleteRequests,
+      },
+    });
+
+    execSync(
+      `aws dynamodb batch-write-item --cli-input-json '${batchInput.replace(/'/g, "'\\''")}'`,
+      { stdio: 'pipe' },
+    );
+
+    console.log(`  Deleted batch ${Math.floor(i / BATCH_SIZE) + 1}: ${batch.length} items`);
+  }
+}
+
+function verifyTestAccount() {
+  console.log('Verifying account is a test account...');
+
+  const pk = `ACCOUNT#${ACCOUNT_ID}`;
+  const item = dynamoGetItem(pk, 'META');
+
+  if (!item) {
+    console.error(`ERROR: Account ${ACCOUNT_ID} not found in DynamoDB.`);
+    process.exit(1);
+  }
+
+  const accountType = item.accountType?.S;
+  if (accountType !== 'test') {
+    console.error('');
+    console.error('╔══════════════════════════════════════════════════════════╗');
+    console.error('║  SAFETY CHECK FAILED: Cannot delete a live account!     ║');
+    console.error('╠══════════════════════════════════════════════════════════╣');
+    console.error(`║  Account ID:   ${ACCOUNT_ID}`);
+    console.error(`║  Account Type: ${accountType || 'undefined'}`);
+    console.error('║                                                          ║');
+    console.error('║  This script only deletes accounts with                  ║');
+    console.error('║  accountType="test". Live accounts are protected.        ║');
+    console.error('╚══════════════════════════════════════════════════════════╝');
+    console.error('');
+    process.exit(1);
+  }
+
+  console.log(`  Verified: accountType=test (${item.beneficiaryName?.S || 'unknown'})`);
+}
+
+function deleteAllDynamoItems() {
+  console.log('Querying all items for account partition...');
+
+  const pk = `ACCOUNT#${ACCOUNT_ID}`;
+  const items = dynamoQueryPartition(pk);
+
+  if (items.length === 0) {
+    console.log('  No items found.');
+    return;
+  }
+
+  console.log(`  Found ${items.length} items to delete.`);
+
+  // Categorize for logging
+  const meta = items.filter((i) => i.SK?.S === 'META');
+  const users = items.filter((i) => i.SK?.S?.startsWith('USER#'));
+  const expenses = items.filter((i) => i.SK?.S?.startsWith('EXP#'));
+  const other = items.filter(
+    (i) => !['META'].includes(i.SK?.S) && !i.SK?.S?.startsWith('USER#') && !i.SK?.S?.startsWith('EXP#'),
+  );
+
+  console.log(`    META items: ${meta.length}`);
+  console.log(`    User items: ${users.length}`);
+  console.log(`    Expense items: ${expenses.length}`);
+  if (other.length > 0) {
+    console.log(`    Other items: ${other.length}`);
+  }
+
+  dynamoBatchDelete(items);
+  console.log('  All DynamoDB items deleted.');
+}
+
+function deleteS3Receipts() {
+  if (!RECEIPT_BUCKET) {
+    console.log('Skipping S3 cleanup (RECEIPT_BUCKET not set).');
+    return;
+  }
+
+  console.log(`Deleting S3 objects under receipts/${ACCOUNT_ID}/...`);
+
+  try {
+    awsCli(
+      `s3 rm "s3://${RECEIPT_BUCKET}/receipts/${ACCOUNT_ID}/" --recursive`,
+    );
+    console.log('  S3 objects deleted.');
+  } catch (err) {
+    // Ignore if no objects found
+    console.log('  No S3 objects found (or already deleted).');
+  }
+}
+
+function deleteCognitoUsers() {
+  console.log('Finding Cognito users for this account...');
+
+  // List users with the matching custom:accountId
+  try {
+    const result = awsCli(
+      `cognito-idp list-users --user-pool-id "${USER_POOL_ID}" --filter "custom:accountId = \\"${ACCOUNT_ID}\\""`,
+    );
+
+    const data = JSON.parse(result);
+    const users = data.Users ?? [];
+
+    if (users.length === 0) {
+      console.log('  No Cognito users found for this account.');
+      return;
+    }
+
+    console.log(`  Found ${users.length} Cognito user(s) to delete.`);
+
+    for (const user of users) {
+      const username = user.Username;
+      console.log(`  Deleting Cognito user: ${username}...`);
+      awsCli(
+        `cognito-idp admin-delete-user --user-pool-id "${USER_POOL_ID}" --username "${username}"`,
+      );
+      console.log(`    Deleted: ${username}`);
+    }
+  } catch (err) {
+    console.error(`  Warning: Failed to list/delete Cognito users: ${err.message}`);
+    console.error('  You may need to manually delete Cognito users.');
+  }
+}
+
+function main() {
+  console.log('=== Delete Test Account ===');
+  console.log(`Region: ${AWS_REGION}`);
+  console.log(`User Pool: ${USER_POOL_ID}`);
+  console.log(`Table: ${TABLE_NAME}`);
+  console.log(`Account ID: ${ACCOUNT_ID}`);
+  console.log('');
+
+  verifyTestAccount();
+  deleteAllDynamoItems();
+  deleteS3Receipts();
+  deleteCognitoUsers();
+
+  console.log('');
+  console.log(`Test account ${ACCOUNT_ID} deleted successfully.`);
+}
+
+try {
+  main();
+} catch (err) {
+  console.error('Delete test account failed:', err.message);
+  process.exit(1);
+}

--- a/scripts/seed-test-account.mjs
+++ b/scripts/seed-test-account.mjs
@@ -1,0 +1,317 @@
+#!/usr/bin/env node
+
+// Schema source of truth: api/src/lib/dynamo.ts
+
+/**
+ * Seeds a test account with realistic sample expenses across all 11 ABLE categories.
+ *
+ * Assumes the test account and user already exist (created by create-test-account.mjs).
+ *
+ * Required environment variables:
+ *   AWS_REGION    — AWS region
+ *   TABLE_NAME    — DynamoDB table name
+ *   ACCOUNT_ID    — The test account ID to seed
+ *   SUBMITTED_BY  — Email of the user submitting expenses
+ *
+ * Optional:
+ *   PAID_BY_ALT   — Display name of a second payer (for multi-user testing)
+ */
+
+import { execSync } from 'node:child_process';
+import { randomBytes } from 'node:crypto';
+
+const AWS_REGION = requiredEnv('AWS_REGION');
+const TABLE_NAME = requiredEnv('TABLE_NAME');
+const ACCOUNT_ID = requiredEnv('ACCOUNT_ID');
+const SUBMITTED_BY = requiredEnv('SUBMITTED_BY');
+const PAID_BY_ALT = process.env.PAID_BY_ALT || '';
+
+function requiredEnv(name) {
+  const value = process.env[name];
+  if (!value) {
+    console.error(`ERROR: Missing required environment variable: ${name}`);
+    process.exit(1);
+  }
+  return value;
+}
+
+/**
+ * Generate a simple unique ID for expenses.
+ */
+function generateExpenseId(prefix) {
+  const rand = randomBytes(4).toString('hex');
+  return `${prefix}-${rand}`;
+}
+
+/**
+ * Insert a DynamoDB item via the AWS CLI.
+ */
+function dynamoPutItem(item) {
+  const putItemInput = JSON.stringify({
+    TableName: TABLE_NAME,
+    Item: item,
+  });
+
+  execSync(
+    `aws dynamodb put-item --cli-input-json '${putItemInput.replace(/'/g, "'\\''")}'`,
+    { stdio: 'pipe' },
+  );
+}
+
+/**
+ * Build a DynamoDB expense item in DynamoDB JSON format.
+ */
+function buildExpenseItem(expense) {
+  const reimbursedFlag = expense.reimbursed ? '1' : '0';
+  const item = {
+    PK: { S: `ACCOUNT#${ACCOUNT_ID}` },
+    SK: { S: `EXP#${expense.date}#${expense.id}` },
+    GSI1PK: { S: `ACCOUNT#${ACCOUNT_ID}` },
+    GSI1SK: { S: `CAT#${expense.category}#${expense.date}` },
+    GSI2PK: { S: `ACCOUNT#${ACCOUNT_ID}` },
+    GSI2SK: { S: `PAID#${expense.paidBy}#${reimbursedFlag}#${expense.date}` },
+    expenseId: { S: expense.id },
+    accountId: { S: ACCOUNT_ID },
+    vendor: { S: expense.vendor },
+    description: { S: expense.description },
+    amount: { N: String(expense.amount) },
+    category: { S: expense.category },
+    categoryConfidence: { S: expense.confidence || 'user_selected' },
+    categoryNotes: { S: expense.notes || '' },
+    receiptKey: { NULL: true },
+    date: { S: expense.date },
+    paidBy: { S: expense.paidBy },
+    submittedBy: { S: SUBMITTED_BY },
+    reimbursed: { BOOL: expense.reimbursed || false },
+    reimbursedAt: expense.reimbursed
+      ? { S: new Date().toISOString() }
+      : { NULL: true },
+    createdAt: { S: new Date().toISOString() },
+    updatedAt: { S: new Date().toISOString() },
+  };
+  return item;
+}
+
+function getSampleExpenses() {
+  const today = new Date();
+  const primaryPayer = 'Test User';
+  const altPayer = PAID_BY_ALT || 'Family Member';
+
+  // Generate dates spread over the last 90 days
+  function daysAgo(n) {
+    const d = new Date(today);
+    d.setDate(d.getDate() - n);
+    return d.toISOString().split('T')[0];
+  }
+
+  return [
+    // Education
+    {
+      id: generateExpenseId('seed'),
+      vendor: 'Community College',
+      description: 'Online course enrollment fee',
+      amount: 35000,
+      category: 'Education',
+      date: daysAgo(85),
+      paidBy: primaryPayer,
+      confidence: 'ai_confirmed',
+      notes: 'Directly education-related',
+    },
+    // Housing
+    {
+      id: generateExpenseId('seed'),
+      vendor: 'City Apartments',
+      description: 'Monthly rent payment',
+      amount: 125000,
+      category: 'Housing',
+      date: daysAgo(60),
+      paidBy: primaryPayer,
+      confidence: 'ai_confirmed',
+      notes: 'Primary residence expense',
+    },
+    // Transportation
+    {
+      id: generateExpenseId('seed'),
+      vendor: 'City Transit Authority',
+      description: 'Monthly bus and subway pass',
+      amount: 7500,
+      category: 'Transportation',
+      date: daysAgo(45),
+      paidBy: altPayer,
+      confidence: 'ai_confirmed',
+      notes: 'Public transportation',
+    },
+    // Employment training & support
+    {
+      id: generateExpenseId('seed'),
+      vendor: 'Job Skills Center',
+      description: 'Resume writing workshop',
+      amount: 15000,
+      category: 'Employment training & support',
+      date: daysAgo(40),
+      paidBy: primaryPayer,
+      confidence: 'ai_suggested',
+      notes: 'Vocational training service',
+    },
+    // Assistive technology & personal support
+    {
+      id: generateExpenseId('seed'),
+      vendor: 'Assistive Tech Store',
+      description: 'Screen reader software license',
+      amount: 29900,
+      category: 'Assistive technology & personal support',
+      date: daysAgo(35),
+      paidBy: primaryPayer,
+      confidence: 'ai_confirmed',
+      notes: 'Assistive technology for computer access',
+    },
+    // Health, prevention & wellness
+    {
+      id: generateExpenseId('seed'),
+      vendor: 'CVS Pharmacy',
+      description: 'Monthly prescription medications',
+      amount: 4500,
+      category: 'Health, prevention & wellness',
+      date: daysAgo(30),
+      paidBy: primaryPayer,
+      confidence: 'ai_confirmed',
+      notes: 'Prescription medication',
+      reimbursed: true,
+    },
+    // Financial management & administrative
+    {
+      id: generateExpenseId('seed'),
+      vendor: 'ABLE Account Services',
+      description: 'Annual account maintenance fee',
+      amount: 2500,
+      category: 'Financial management & administrative',
+      date: daysAgo(25),
+      paidBy: altPayer,
+      confidence: 'ai_confirmed',
+      notes: 'ABLE account administration',
+    },
+    // Legal fees
+    {
+      id: generateExpenseId('seed'),
+      vendor: 'Disability Law Center',
+      description: 'Benefits eligibility consultation',
+      amount: 20000,
+      category: 'Legal fees',
+      date: daysAgo(20),
+      paidBy: primaryPayer,
+      confidence: 'ai_suggested',
+      notes: 'Legal consultation related to disability benefits',
+    },
+    // Oversight & monitoring
+    {
+      id: generateExpenseId('seed'),
+      vendor: 'Trust Services Inc',
+      description: 'Quarterly account review fee',
+      amount: 7500,
+      category: 'Oversight & monitoring',
+      date: daysAgo(15),
+      paidBy: primaryPayer,
+      confidence: 'user_selected',
+      notes: 'Account oversight service',
+    },
+    // Funeral & burial (pre-paid)
+    {
+      id: generateExpenseId('seed'),
+      vendor: 'Memorial Planning Co',
+      description: 'Pre-paid funeral plan installment',
+      amount: 10000,
+      category: 'Funeral & burial',
+      date: daysAgo(10),
+      paidBy: altPayer,
+      confidence: 'ai_confirmed',
+      notes: 'Pre-paid burial expense',
+    },
+    // Basic living expenses
+    {
+      id: generateExpenseId('seed'),
+      vendor: 'Whole Foods Market',
+      description: 'Weekly groceries',
+      amount: 8725,
+      category: 'Basic living expenses',
+      date: daysAgo(5),
+      paidBy: primaryPayer,
+      confidence: 'ai_confirmed',
+      notes: 'Food and grocery expenses',
+    },
+    // Extra expenses for variety
+    {
+      id: generateExpenseId('seed'),
+      vendor: 'Uber',
+      description: 'Medical appointment transportation',
+      amount: 2450,
+      category: 'Transportation',
+      date: daysAgo(3),
+      paidBy: altPayer,
+      confidence: 'ai_suggested',
+      notes: 'Ride to medical appointment',
+    },
+    {
+      id: generateExpenseId('seed'),
+      vendor: 'Walgreens',
+      description: 'Over-the-counter wellness supplies',
+      amount: 3299,
+      category: 'Health, prevention & wellness',
+      date: daysAgo(1),
+      paidBy: primaryPayer,
+      confidence: 'ai_confirmed',
+      notes: 'Health and wellness products',
+    },
+  ];
+}
+
+function main() {
+  console.log('=== Seed Test Account ===');
+  console.log(`Region: ${AWS_REGION}`);
+  console.log(`Table: ${TABLE_NAME}`);
+  console.log(`Account ID: ${ACCOUNT_ID}`);
+  console.log(`Submitted By: ${SUBMITTED_BY}`);
+  console.log('');
+
+  const expenses = getSampleExpenses();
+
+  console.log(`Seeding ${expenses.length} expenses across all 11 ABLE categories...`);
+  console.log('');
+
+  let totalAmount = 0;
+  const categoryCounts = {};
+
+  for (const expense of expenses) {
+    const item = buildExpenseItem(expense);
+    dynamoPutItem(item);
+
+    totalAmount += expense.amount;
+    categoryCounts[expense.category] = (categoryCounts[expense.category] || 0) + 1;
+
+    const status = expense.reimbursed ? ' [REIMBURSED]' : '';
+    console.log(`  ${expense.vendor} — $${(expense.amount / 100).toFixed(2)} (${expense.category})${status}`);
+  }
+
+  console.log('');
+  console.log('Summary:');
+  console.log(`  Total expenses: ${expenses.length}`);
+  console.log(`  Total amount: $${(totalAmount / 100).toFixed(2)}`);
+  console.log(`  Categories covered: ${Object.keys(categoryCounts).length}/11`);
+  console.log(`  Reimbursed: ${expenses.filter((e) => e.reimbursed).length}`);
+  console.log(`  Unreimbursed: ${expenses.filter((e) => !e.reimbursed).length}`);
+  console.log('');
+
+  console.log('Category breakdown:');
+  for (const [cat, count] of Object.entries(categoryCounts).sort()) {
+    console.log(`  ${cat}: ${count}`);
+  }
+
+  console.log('');
+  console.log('Seeding complete.');
+}
+
+try {
+  main();
+} catch (err) {
+  console.error('Seed test account failed:', err.message);
+  process.exit(1);
+}

--- a/scripts/seed-test-data.mjs
+++ b/scripts/seed-test-data.mjs
@@ -136,6 +136,7 @@ function verifyCognitoUser() {
     { field: 'email', expected: E2E_EMAIL, actual: attrs.email },
     { field: 'custom:role', expected: 'owner', actual: attrs['custom:role'] },
     { field: 'custom:accountId', expected: 'ACCT-E2E-TEST', actual: attrs['custom:accountId'] },
+    { field: 'custom:accountType', expected: 'test', actual: attrs['custom:accountType'] },
   ];
 
   const mismatches = checks.filter((c) => c.expected !== c.actual);
@@ -147,7 +148,7 @@ function verifyCognitoUser() {
     process.exit(1);
   }
 
-  console.log(`  Verified: user=${E2E_EMAIL}, role=owner, accountId=ACCT-E2E-TEST`);
+  console.log(`  Verified: user=${E2E_EMAIL}, role=owner, accountId=ACCT-E2E-TEST, accountType=test`);
 }
 
 function createTestUser() {
@@ -157,7 +158,7 @@ function createTestUser() {
     awsCli(
       `cognito-idp admin-create-user --user-pool-id "${USER_POOL_ID}" --username "${E2E_EMAIL}" ` +
       `--temporary-password "${E2E_PASSWORD}" ` +
-      `--user-attributes Name=email,Value="${E2E_EMAIL}" Name=email_verified,Value=true Name=custom:role,Value=owner Name=custom:accountId,Value=ACCT-E2E-TEST ` +
+      `--user-attributes Name=email,Value="${E2E_EMAIL}" Name=email_verified,Value=true Name=custom:role,Value=owner Name=custom:accountId,Value=ACCT-E2E-TEST Name=custom:accountType,Value=test ` +
       `--message-action SUPPRESS`,
     );
   } catch (err) {
@@ -175,6 +176,40 @@ function createTestUser() {
   );
 
   console.log(`  User created: ${E2E_EMAIL}`);
+}
+
+function seedAccountAndUser() {
+  console.log('Seeding Account and User items...');
+
+  const accountId = 'ACCT-E2E-TEST';
+  const now = new Date().toISOString();
+
+  // Account META item
+  const accountItem = {
+    PK: { S: `ACCOUNT#${accountId}` },
+    SK: { S: 'META' },
+    id: { S: accountId },
+    beneficiaryName: { S: 'E2E Test Beneficiary' },
+    accountType: { S: 'test' },
+    createdAt: { S: now },
+    createdBy: { S: E2E_EMAIL },
+  };
+  dynamoPutItem(accountItem);
+  console.log(`  Seeded Account META: ${accountId} (accountType=test)`);
+
+  // User item
+  const userItem = {
+    PK: { S: `ACCOUNT#${accountId}` },
+    SK: { S: 'USER#e2e-test-user' },
+    userId: { S: 'e2e-test-user' },
+    accountId: { S: accountId },
+    email: { S: E2E_EMAIL },
+    displayName: { S: 'E2E Test User' },
+    role: { S: 'owner' },
+    cognitoSub: { S: 'pending' },
+  };
+  dynamoPutItem(userItem);
+  console.log(`  Seeded User: e2e-test-user (${E2E_EMAIL})`);
 }
 
 function seedExpenses() {
@@ -272,6 +307,7 @@ function main() {
 
   createTestUser();
   verifyCognitoUser();
+  seedAccountAndUser();
   seedExpenses();
   writeGitHubOutput();
 

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -28,9 +28,12 @@ export const ABLE_CATEGORIES = [
   'Basic living expenses',
 ] as const;
 
+export type AccountType = 'live' | 'test';
+
 export interface Account {
   id: string;
   beneficiaryName: string;
+  accountType: AccountType;
   createdAt: string;
   createdBy: string;
 }


### PR DESCRIPTION
## Summary

- Add `accountType: 'live' | 'test'` to the `Account` interface with immutable Cognito attribute (`custom:accountType`) and backwards-compatible AuthContext extraction (defaults to `'live'`)
- New `AccountRepository` (PK=`ACCOUNT#<id>`, SK=`META`) and `UserRepository` (PK=`ACCOUNT#<id>`, SK=`USER#<userId>`) with full TDD test suites
- Admin scripts: `create-test-account.mjs`, `delete-test-account.mjs` (with safety check refusing to delete live accounts), and `seed-test-account.mjs` (seeds all 11 ABLE categories)
- Updated `seed-test-data.mjs` to label E2E accounts as `accountType=test` and seed Account/User DynamoDB items

## Test plan

- [x] 6 new auth middleware tests (accountType extraction + backwards compat default)
- [x] 13 new AccountRepository tests (create, get, delete, key patterns, accountType default)
- [x] 15 new UserRepository tests (create, get, list, delete, deleteAll, key stripping)
- [x] 3 new CDK assertion tests (custom:accountType attribute immutable, readable, not writable)
- [x] All 736 tests pass (api: 294, infra: 122, web: 320)
- [x] TypeScript strict compilation clean
- [ ] Deploy to ephemeral environment and run `create-test-account.mjs` / `delete-test-account.mjs` end-to-end
- [ ] Verify `delete-test-account.mjs` refuses to delete a live account

Closes #29

https://claude.ai/code/session_01CdN2BUHB4po86d86SVacu8