### PR TITLE
docs: add Google OAuth setup guide (#22)

### DIFF
--- a/deployment.env.example
+++ b/deployment.env.example
@@ -35,6 +35,16 @@ COGNITO_USER_POOL_ID=us-east-1_XXXXXXXXX
 # Found in CDK output: AbleTrackerAuthStack.UserPoolClientId
 COGNITO_CLIENT_ID=xxxxxxxxxxxxxxxxxxxxxxxxxx
 
+# ─── Google OAuth (Optional) ───────────────────────────────────
+# Enable Google Sign-In. Set to "true" to show the Google button on the login page.
+# Requires Google OAuth credentials stored in SSM Parameter Store.
+# See docs/SETUP.md "Google OAuth (Optional)" for full setup instructions.
+# VITE_GOOGLE_IDP_ENABLED=true
+
+# The Cognito hosted UI domain. Required when Google OAuth is enabled.
+# Found in CDK output: AbleTrackerAuthStack.UserPoolDomainOutput
+# VITE_COGNITO_DOMAIN=https://able-tracker.auth.us-east-1.amazoncognito.com
+
 # ─── AWS ─────────────────────────────────────────────────────────
 # The AWS region where the stack is deployed.
 AWS_REGION=us-east-1

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -71,7 +71,7 @@ npx cdk deploy --all
 ```
 
 This deploys four stacks in dependency order:
-- **AbleTracker-Auth** — Cognito User Pool and Identity Pool
+- **AbleTracker-Auth** — Cognito User Pool (and optional Google Identity Provider)
 - **AbleTracker-Data** — DynamoDB tables and S3 buckets
 - **AbleTracker-Api** — API Gateway and Lambda functions
 - **AbleTracker-Hosting** — S3 static hosting and CloudFront distribution
@@ -125,6 +125,100 @@ GitHub Actions workflows require secrets configured in your repository. Go to **
 | Variable | Description |
 |----------|-------------|
 | `AWS_REGION` | AWS region for deployments (e.g., `us-east-1`) |
+
+## Google OAuth (Optional)
+
+ABLE Tracker supports "Sign in with Google" as an alternative to username/password authentication. This is entirely optional — the app works without it.
+
+> **Note:** Google OAuth is automatically skipped in ephemeral/CI environments. It only applies to production deployments.
+
+### Prerequisites
+
+- Base ABLE Tracker deployment already complete (steps 1-5 above)
+- A Google Cloud account
+- AWS CLI configured with access to your deployment account
+
+### Step 1: Create Google Cloud OAuth Credentials
+
+1. Go to the [Google Cloud Console Credentials page](https://console.cloud.google.com/apis/credentials)
+2. Create a new project (or select an existing one)
+3. Navigate to **APIs & Services > OAuth consent screen**
+   - Choose **External** user type
+   - Fill in the app name (e.g., "ABLE Tracker"), support email, and developer contact email
+   - Add the scopes: `openid`, `email`, `profile`
+   - Save
+4. Navigate to **APIs & Services > Credentials**
+   - Click **Create Credentials > OAuth 2.0 Client ID**
+   - Application type: **Web application**
+   - Name: e.g., "ABLE Tracker"
+   - Under **Authorized redirect URIs**, add:
+     ```
+     https://able-tracker.auth.<your-region>.amazoncognito.com/oauth2/idpresponse
+     ```
+     Replace `<your-region>` with your AWS region (e.g., `us-east-1`).
+   - Click **Create**
+5. Copy the **Client ID** and **Client Secret** — you will need them in the next step
+
+### Step 2: Store Credentials in AWS SSM Parameter Store
+
+Store the Google OAuth credentials so CDK can reference them during deployment:
+
+```bash
+aws ssm put-parameter \
+  --name "/able-tracker/google-oauth-client-id" \
+  --type "String" \
+  --value "YOUR_GOOGLE_CLIENT_ID"
+
+aws ssm put-parameter \
+  --name "/able-tracker/google-oauth-client-secret" \
+  --type "SecureString" \
+  --value "YOUR_GOOGLE_CLIENT_SECRET"
+```
+
+Replace `YOUR_GOOGLE_CLIENT_ID` and `YOUR_GOOGLE_CLIENT_SECRET` with the values from Step 1.
+
+### Step 3: Configure Frontend Environment Variables
+
+Add these variables to your frontend environment (e.g., `web/.env.local` for local development, or your CI/deployment configuration):
+
+```bash
+VITE_COGNITO_DOMAIN=https://able-tracker.auth.us-east-1.amazoncognito.com
+VITE_GOOGLE_IDP_ENABLED=true
+```
+
+Replace the domain with your actual Cognito domain URL. After deploying (Step 4), you can find this value in the CDK stack output `UserPoolDomainOutput`.
+
+### Step 4: Deploy
+
+Re-deploy the infrastructure to create the Cognito domain and Google Identity Provider:
+
+```bash
+pnpm --filter infra run cdk deploy --all
+```
+
+Then rebuild and deploy the frontend so the Google sign-in button appears:
+
+```bash
+pnpm --filter web run build
+```
+
+Deploy the built frontend to your S3 hosting bucket (see your deployment workflow for the exact command).
+
+### Step 5: Verify
+
+1. Visit the login page
+2. A **Sign in with Google** button should appear below the email/password form
+3. Click it — you should be redirected to the Google consent screen
+4. After granting consent, you should be redirected back and logged in
+
+### Troubleshooting
+
+| Problem | Solution |
+|---------|----------|
+| `redirect_mismatch` error from Google | The authorized redirect URI in Google Cloud Console must match exactly: `https://able-tracker.auth.<region>.amazoncognito.com/oauth2/idpresponse` |
+| Google button not showing on login page | Verify `VITE_GOOGLE_IDP_ENABLED=true` is set in the frontend environment and the app was rebuilt |
+| Token exchange fails after Google consent | Verify both SSM parameters exist (`aws ssm get-parameter --name /able-tracker/google-oauth-client-id`) and that CDK deployed successfully |
+| "State mismatch" error on callback | Try clearing browser session storage and signing in again — this can happen if the sign-in flow was interrupted |
 
 ## Teardown
 


### PR DESCRIPTION
## Summary

- Adds a complete "Google OAuth (Optional)" section to `docs/SETUP.md` covering Google Cloud Console setup, SSM parameter storage, frontend env vars, deployment, verification, and troubleshooting
- Adds optional `VITE_COGNITO_DOMAIN` and `VITE_GOOGLE_IDP_ENABLED` variables to `deployment.env.example`
- Updates the deployment overview to note the Auth stack includes the optional Google Identity Provider

Closes #22

## Test plan

- [ ] Verify all `aws ssm put-parameter` commands are copy-pasteable
- [ ] Verify SSM parameter paths match `infra/lib/auth-stack.ts` (`/able-tracker/google-oauth-client-id`, `/able-tracker/google-oauth-client-secret`)
- [ ] Verify env var names match `web/src/lib/config.ts` (`VITE_COGNITO_DOMAIN`, `VITE_GOOGLE_IDP_ENABLED`)
- [ ] Verify Cognito domain prefix matches CDK code (`able-tracker`)
- [ ] Verify troubleshooting section covers common pitfalls

🤖 Generated with [Claude Code](https://claude.com/claude-code)